### PR TITLE
Fix the width of the Slack example

### DIFF
--- a/demo/src/playground/SlackPickerExample.tsx
+++ b/demo/src/playground/SlackPickerExample.tsx
@@ -2,23 +2,23 @@ import { EmojiPicker } from '@ferrucc-io/emoji-picker';
 
 export function SlackPickerExample() {
   return (
-    <div className="rounded-[8px] border border-zinc-300 dark:border-zinc-600 overflow-hidden shadow-sm pt-1 max-w-[300px]">
+    <div className="rounded-[8px] border border-zinc-300 dark:border-zinc-600 overflow-hidden shadow-sm flex flex-col items-center">
       <EmojiPicker 
-        className="font-['Lato'] w-[300px] border-none"
+        className="font-['Lato'] w-[380px] border-none"
         emojisPerRow={9}
         emojiSize={36}
       >
-        <EmojiPicker.Header className="w-full">
+        <EmojiPicker.Header className="w-full px-4 pt-4">
           <EmojiPicker.Input 
             placeholder="Search all emoji" 
             className="h-[36px] bg-white dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-600 w-full rounded-[8px] text-[15px] focus:shadow-[0_0_0_1px_#1d9bd1,0_0_0_6px_rgba(29,155,209,0.3)] dark:focus:shadow-[0_0_0_1px_#1d9bd1,0_0_0_6px_rgba(29,155,209,0.3)] focus:border-transparent focus:outline-none mb-1"
             hideIcon
           />
         </EmojiPicker.Header>
-        <EmojiPicker.Group>
+        <EmojiPicker.Group className="px-1">
           <EmojiPicker.List containerHeight={320} />          
         </EmojiPicker.Group>
-        <EmojiPicker.Preview>
+        <EmojiPicker.Preview className="px-4">
           {({ previewedEmoji }) => (
             <>
               {previewedEmoji ? 

--- a/packages/emoji-picker/src/EmojiPicker/EmojiPickerGroup.tsx
+++ b/packages/emoji-picker/src/EmojiPicker/EmojiPickerGroup.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
+import { cn } from '../utils/cn';
 
 export interface EmojiPickerGroupProps {
   children: React.ReactNode;
   title?: string;
+  className?: string;
 }
 
-export function EmojiPickerGroup({ children }: EmojiPickerGroupProps) {
+export function EmojiPickerGroup({ children, className }: EmojiPickerGroupProps) {
   return (
     <div className="flex-1 overflow-hidden">
-      <div className="h-full overflow-y-auto overscroll-contain will-change-scroll">
+      <div className={cn("h-full overflow-y-auto overscroll-contain will-change-scroll", className)}>
         {children}
       </div>
     </div>

--- a/packages/emoji-picker/src/EmojiPicker/EmojiPickerPreview.tsx
+++ b/packages/emoji-picker/src/EmojiPicker/EmojiPickerPreview.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
 import { useEmojiPicker } from './EmojiPickerContext';
+import { cn } from '../utils/cn';
 
 import type { EmojiMetadata } from '../types/emoji';
-
 interface EmojiPickerPreviewProps {
   children: (props: { previewedEmoji: EmojiMetadata | null }) => React.ReactNode;
+  className?: string;
 }
 
-export function EmojiPickerPreview({ children }: EmojiPickerPreviewProps) {
+export function EmojiPickerPreview({ children, className }: EmojiPickerPreviewProps) {
   const { hoveredEmoji, emojiSize } = useEmojiPicker();
   const containerHeight = Math.max(emojiSize * 1.1, 44); // Minimum height of 44px for better UX
 
   return (
-    <div className="flex items-center border-t border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900 p-2">
+    <div className={cn("flex items-center border-t border-zinc-200 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900 p-2", className)}>
       <div className="flex items-center justify-between w-full" style={{ height: `${containerHeight}px` }}>
         {children({ previewedEmoji: hoveredEmoji })}
       </div>


### PR DESCRIPTION
Each row has 9 emojis with 36width and there's 8px of padding on the x axis

We need at least 340px to render this component

Fixes #17

Looks much more like the original one:
![Screenshot 2025-01-26 at 21 32 43](https://github.com/user-attachments/assets/32b4ab15-1a40-4ccd-8d04-0a30cf60d66f)

