### PR TITLE
Add unit tests, e2e tests, and Playwright CI job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,30 +9,58 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     steps:
-      - uses: actions/checkout@v5
-      
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
-          
+
       - name: Install dependencies
         run: bun install
-        
+
       - name: Check formatting
         run: |
           bun run format:check
-        
+
       - name: Run linting
         run: bun run lint
-        
+
       - name: Run tests
         run: bun run test
-        
+
       - name: Build library
         run: bun run build
-        
-      - name: Build demo
-        run: bun run build
+
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      - name: Build library
+        run: bun run --cwd packages/emoji-picker build
+
+      - name: Run Playwright tests
+        run: bun run test:e2e
+
+      - name: Upload test results
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: test-results/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,7 @@ dist
 .yarn/install-state.gz
 .pnp.*
 .aider*
+
+# Playwright
+test-results/
+playwright-report/

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "emojicn",
+      "devDependencies": {
+        "@playwright/test": "^1.59.1",
+      },
     },
     "demo": {
       "name": "@ferrucc-io/emoji-picker-demo",
@@ -74,9 +77,20 @@
         "vite": "^7.1.9",
       },
       "peerDependencies": {
-        "react": "^18.3.0 || ^19.0.0",
-        "react-dom": "^18.3.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
         "tailwindcss": ">=3.0.0",
+      },
+    },
+    "packages/server": {
+      "name": "@ferrucc-io/emoji-picker-server",
+      "version": "0.0.1",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.709.0",
+        "sharp": "^0.33.5",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
       },
     },
   },
@@ -84,6 +98,88 @@
     "@adobe/css-tools": ["@adobe/css-tools@4.4.1", "", {}, "sha512-12WGKBQzjUAI4ayyF4IAtfw2QR/IDoqk6jTddXDhtYTJF9ASmoE1zst7cVtP0aL/F1jUJL5r+JxKXKEgHNbEUQ=="],
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
+    "@aws-crypto/crc32": ["@aws-crypto/crc32@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg=="],
+
+    "@aws-crypto/crc32c": ["@aws-crypto/crc32c@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag=="],
+
+    "@aws-crypto/sha1-browser": ["@aws-crypto/sha1-browser@5.2.0", "", { "dependencies": { "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.958.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "3.957.0", "@aws-sdk/credential-provider-node": "3.958.0", "@aws-sdk/middleware-bucket-endpoint": "3.957.0", "@aws-sdk/middleware-expect-continue": "3.957.0", "@aws-sdk/middleware-flexible-checksums": "3.957.0", "@aws-sdk/middleware-host-header": "3.957.0", "@aws-sdk/middleware-location-constraint": "3.957.0", "@aws-sdk/middleware-logger": "3.957.0", "@aws-sdk/middleware-recursion-detection": "3.957.0", "@aws-sdk/middleware-sdk-s3": "3.957.0", "@aws-sdk/middleware-ssec": "3.957.0", "@aws-sdk/middleware-user-agent": "3.957.0", "@aws-sdk/region-config-resolver": "3.957.0", "@aws-sdk/signature-v4-multi-region": "3.957.0", "@aws-sdk/types": "3.957.0", "@aws-sdk/util-endpoints": "3.957.0", "@aws-sdk/util-user-agent-browser": "3.957.0", "@aws-sdk/util-user-agent-node": "3.957.0", "@smithy/config-resolver": "^4.4.5", "@smithy/core": "^3.20.0", "@smithy/eventstream-serde-browser": "^4.2.7", "@smithy/eventstream-serde-config-resolver": "^4.3.7", "@smithy/eventstream-serde-node": "^4.2.7", "@smithy/fetch-http-handler": "^5.3.8", "@smithy/hash-blob-browser": "^4.2.8", "@smithy/hash-node": "^4.2.7", "@smithy/hash-stream-node": "^4.2.7", "@smithy/invalid-dependency": "^4.2.7", "@smithy/md5-js": "^4.2.7", "@smithy/middleware-content-length": "^4.2.7", "@smithy/middleware-endpoint": "^4.4.1", "@smithy/middleware-retry": "^4.4.17", "@smithy/middleware-serde": "^4.2.8", "@smithy/middleware-stack": "^4.2.7", "@smithy/node-config-provider": "^4.3.7", "@smithy/node-http-handler": "^4.4.7", "@smithy/protocol-http": "^5.3.7", "@smithy/smithy-client": "^4.10.2", "@smithy/types": "^4.11.0", "@smithy/url-parser": "^4.2.7", "@smithy/util-base64": "^4.3.0", "@smithy/util-body-length-browser": "^4.2.0", "@smithy/util-body-length-node": "^4.2.1", "@smithy/util-defaults-mode-browser": "^4.3.16", "@smithy/util-defaults-mode-node": "^4.2.19", "@smithy/util-endpoints": "^3.2.7", "@smithy/util-middleware": "^4.2.7", "@smithy/util-retry": "^4.2.7", "@smithy/util-stream": "^4.5.8", "@smithy/util-utf8": "^4.2.0", "@smithy/util-waiter": "^4.2.7", "tslib": "^2.6.2" } }, "sha512-ol8Sw37AToBWb6PjRuT/Wu40SrrZSA0N4F7U3yTkjUNX0lirfO1VFLZ0hZtZplVJv8GNPITbiczxQ8VjxESXxg=="],
+
+    "@aws-sdk/client-sso": ["@aws-sdk/client-sso@3.958.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "3.957.0", "@aws-sdk/middleware-host-header": "3.957.0", "@aws-sdk/middleware-logger": "3.957.0", "@aws-sdk/middleware-recursion-detection": "3.957.0", "@aws-sdk/middleware-user-agent": "3.957.0", "@aws-sdk/region-config-resolver": "3.957.0", "@aws-sdk/types": "3.957.0", "@aws-sdk/util-endpoints": "3.957.0", "@aws-sdk/util-user-agent-browser": "3.957.0", "@aws-sdk/util-user-agent-node": "3.957.0", "@smithy/config-resolver": "^4.4.5", "@smithy/core": "^3.20.0", "@smithy/fetch-http-handler": "^5.3.8", "@smithy/hash-node": "^4.2.7", "@smithy/invalid-dependency": "^4.2.7", "@smithy/middleware-content-length": "^4.2.7", "@smithy/middleware-endpoint": "^4.4.1", "@smithy/middleware-retry": "^4.4.17", "@smithy/middleware-serde": "^4.2.8", "@smithy/middleware-stack": "^4.2.7", "@smithy/node-config-provider": "^4.3.7", "@smithy/node-http-handler": "^4.4.7", "@smithy/protocol-http": "^5.3.7", "@smithy/smithy-client": "^4.10.2", "@smithy/types": "^4.11.0", "@smithy/url-parser": "^4.2.7", "@smithy/util-base64": "^4.3.0", "@smithy/util-body-length-browser": "^4.2.0", "@smithy/util-body-length-node": "^4.2.1", "@smithy/util-defaults-mode-browser": "^4.3.16", "@smithy/util-defaults-mode-node": "^4.2.19", "@smithy/util-endpoints": "^3.2.7", "@smithy/util-middleware": "^4.2.7", "@smithy/util-retry": "^4.2.7", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-6qNCIeaMzKzfqasy2nNRuYnMuaMebCcCPP4J2CVGkA8QYMbIVKPlkn9bpB20Vxe6H/r3jtCCLQaOJjVTx/6dXg=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.957.0", "", { "dependencies": { "@aws-sdk/types": "3.957.0", "@aws-sdk/xml-builder": "3.957.0", "@smithy/core": "^3.20.0", "@smithy/node-config-provider": "^4.3.7", "@smithy/property-provider": "^4.2.7", "@smithy/protocol-http": "^5.3.7", "@smithy/signature-v4": "^5.3.7", "@smithy/smithy-client": "^4.10.2", "@smithy/types": "^4.11.0", "@smithy/util-base64": "^4.3.0", "@smithy/util-middleware": "^4.2.7", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-DrZgDnF1lQZv75a52nFWs6MExihJF2GZB6ETZRqr6jMwhrk2kbJPUtvgbifwcL7AYmVqHQDJBrR/MqkwwFCpiw=="],
+
+    "@aws-sdk/crc64-nvme": ["@aws-sdk/crc64-nvme@3.957.0", "", { "dependencies": { "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-qSwSfI+qBU9HDsd6/4fM9faCxYJx2yDuHtj+NVOQ6XYDWQzFab/hUdwuKZ77Pi6goLF1pBZhJ2azaC2w7LbnTA=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.957.0", "", { "dependencies": { "@aws-sdk/core": "3.957.0", "@aws-sdk/types": "3.957.0", "@smithy/property-provider": "^4.2.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-475mkhGaWCr+Z52fOOVb/q2VHuNvqEDixlYIkeaO6xJ6t9qR0wpLt4hOQaR6zR1wfZV0SlE7d8RErdYq/PByog=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.957.0", "", { "dependencies": { "@aws-sdk/core": "3.957.0", "@aws-sdk/types": "3.957.0", "@smithy/fetch-http-handler": "^5.3.8", "@smithy/node-http-handler": "^4.4.7", "@smithy/property-provider": "^4.2.7", "@smithy/protocol-http": "^5.3.7", "@smithy/smithy-client": "^4.10.2", "@smithy/types": "^4.11.0", "@smithy/util-stream": "^4.5.8", "tslib": "^2.6.2" } }, "sha512-8dS55QHRxXgJlHkEYaCGZIhieCs9NU1HU1BcqQ4RfUdSsfRdxxktqUKgCnBnOOn0oD3PPA8cQOCAVgIyRb3Rfw=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.958.0", "", { "dependencies": { "@aws-sdk/core": "3.957.0", "@aws-sdk/credential-provider-env": "3.957.0", "@aws-sdk/credential-provider-http": "3.957.0", "@aws-sdk/credential-provider-login": "3.958.0", "@aws-sdk/credential-provider-process": "3.957.0", "@aws-sdk/credential-provider-sso": "3.958.0", "@aws-sdk/credential-provider-web-identity": "3.958.0", "@aws-sdk/nested-clients": "3.958.0", "@aws-sdk/types": "3.957.0", "@smithy/credential-provider-imds": "^4.2.7", "@smithy/property-provider": "^4.2.7", "@smithy/shared-ini-file-loader": "^4.4.2", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-u7twvZa1/6GWmPBZs6DbjlegCoNzNjBsMS/6fvh5quByYrcJr/uLd8YEr7S3UIq4kR/gSnHqcae7y2nL2bqZdg=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.958.0", "", { "dependencies": { "@aws-sdk/core": "3.957.0", "@aws-sdk/nested-clients": "3.958.0", "@aws-sdk/types": "3.957.0", "@smithy/property-provider": "^4.2.7", "@smithy/protocol-http": "^5.3.7", "@smithy/shared-ini-file-loader": "^4.4.2", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-sDwtDnBSszUIbzbOORGh5gmXGl9aK25+BHb4gb1aVlqB+nNL2+IUEJA62+CE55lXSH8qXF90paivjK8tOHTwPA=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.958.0", "", { "dependencies": { "@aws-sdk/credential-provider-env": "3.957.0", "@aws-sdk/credential-provider-http": "3.957.0", "@aws-sdk/credential-provider-ini": "3.958.0", "@aws-sdk/credential-provider-process": "3.957.0", "@aws-sdk/credential-provider-sso": "3.958.0", "@aws-sdk/credential-provider-web-identity": "3.958.0", "@aws-sdk/types": "3.957.0", "@smithy/credential-provider-imds": "^4.2.7", "@smithy/property-provider": "^4.2.7", "@smithy/shared-ini-file-loader": "^4.4.2", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-vdoZbNG2dt66I7EpN3fKCzi6fp9xjIiwEA/vVVgqO4wXCGw8rKPIdDUus4e13VvTr330uQs2W0UNg/7AgtquEQ=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.957.0", "", { "dependencies": { "@aws-sdk/core": "3.957.0", "@aws-sdk/types": "3.957.0", "@smithy/property-provider": "^4.2.7", "@smithy/shared-ini-file-loader": "^4.4.2", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-/KIz9kadwbeLy6SKvT79W81Y+hb/8LMDyeloA2zhouE28hmne+hLn0wNCQXAAupFFlYOAtZR2NTBs7HBAReJlg=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.958.0", "", { "dependencies": { "@aws-sdk/client-sso": "3.958.0", "@aws-sdk/core": "3.957.0", "@aws-sdk/token-providers": "3.958.0", "@aws-sdk/types": "3.957.0", "@smithy/property-provider": "^4.2.7", "@smithy/shared-ini-file-loader": "^4.4.2", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-CBYHJ5ufp8HC4q+o7IJejCUctJXWaksgpmoFpXerbjAso7/Fg7LLUu9inXVOxlHKLlvYekDXjIUBXDJS2WYdgg=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.958.0", "", { "dependencies": { "@aws-sdk/core": "3.957.0", "@aws-sdk/nested-clients": "3.958.0", "@aws-sdk/types": "3.957.0", "@smithy/property-provider": "^4.2.7", "@smithy/shared-ini-file-loader": "^4.4.2", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-dgnvwjMq5Y66WozzUzxNkCFap+umHUtqMMKlr8z/vl9NYMLem/WUbWNpFFOVFWquXikc+ewtpBMR4KEDXfZ+KA=="],
+
+    "@aws-sdk/middleware-bucket-endpoint": ["@aws-sdk/middleware-bucket-endpoint@3.957.0", "", { "dependencies": { "@aws-sdk/types": "3.957.0", "@aws-sdk/util-arn-parser": "3.957.0", "@smithy/node-config-provider": "^4.3.7", "@smithy/protocol-http": "^5.3.7", "@smithy/types": "^4.11.0", "@smithy/util-config-provider": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-iczcn/QRIBSpvsdAS/rbzmoBpleX1JBjXvCynMbDceVLBIcVrwT1hXECrhtIC2cjh4HaLo9ClAbiOiWuqt+6MA=="],
+
+    "@aws-sdk/middleware-expect-continue": ["@aws-sdk/middleware-expect-continue@3.957.0", "", { "dependencies": { "@aws-sdk/types": "3.957.0", "@smithy/protocol-http": "^5.3.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-AlbK3OeVNwZZil0wlClgeI/ISlOt/SPUxBsIns876IFaVu/Pj3DgImnYhpcJuFRek4r4XM51xzIaGQXM6GDHGg=="],
+
+    "@aws-sdk/middleware-flexible-checksums": ["@aws-sdk/middleware-flexible-checksums@3.957.0", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@aws-crypto/crc32c": "5.2.0", "@aws-crypto/util": "5.2.0", "@aws-sdk/core": "3.957.0", "@aws-sdk/crc64-nvme": "3.957.0", "@aws-sdk/types": "3.957.0", "@smithy/is-array-buffer": "^4.2.0", "@smithy/node-config-provider": "^4.3.7", "@smithy/protocol-http": "^5.3.7", "@smithy/types": "^4.11.0", "@smithy/util-middleware": "^4.2.7", "@smithy/util-stream": "^4.5.8", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-iJpeVR5V8se1hl2pt+k8bF/e9JO4KWgPCMjg8BtRspNtKIUGy7j6msYvbDixaKZaF2Veg9+HoYcOhwnZumjXSA=="],
+
+    "@aws-sdk/middleware-host-header": ["@aws-sdk/middleware-host-header@3.957.0", "", { "dependencies": { "@aws-sdk/types": "3.957.0", "@smithy/protocol-http": "^5.3.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-BBgKawVyfQZglEkNTuBBdC3azlyqNXsvvN4jPkWAiNYcY0x1BasaJFl+7u/HisfULstryweJq/dAvIZIxzlZaA=="],
+
+    "@aws-sdk/middleware-location-constraint": ["@aws-sdk/middleware-location-constraint@3.957.0", "", { "dependencies": { "@aws-sdk/types": "3.957.0", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-y8/W7TOQpmDJg/fPYlqAhwA4+I15LrS7TwgUEoxogtkD8gfur9wFMRLT8LCyc9o4NMEcAnK50hSb4+wB0qv6tQ=="],
+
+    "@aws-sdk/middleware-logger": ["@aws-sdk/middleware-logger@3.957.0", "", { "dependencies": { "@aws-sdk/types": "3.957.0", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-w1qfKrSKHf9b5a8O76yQ1t69u6NWuBjr5kBX+jRWFx/5mu6RLpqERXRpVJxfosbep7k3B+DSB5tZMZ82GKcJtQ=="],
+
+    "@aws-sdk/middleware-recursion-detection": ["@aws-sdk/middleware-recursion-detection@3.957.0", "", { "dependencies": { "@aws-sdk/types": "3.957.0", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/protocol-http": "^5.3.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-D2H/WoxhAZNYX+IjkKTdOhOkWQaK0jjJrDBj56hKjU5c9ltQiaX/1PqJ4dfjHntEshJfu0w+E6XJ+/6A6ILBBA=="],
+
+    "@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.957.0", "", { "dependencies": { "@aws-sdk/core": "3.957.0", "@aws-sdk/types": "3.957.0", "@aws-sdk/util-arn-parser": "3.957.0", "@smithy/core": "^3.20.0", "@smithy/node-config-provider": "^4.3.7", "@smithy/protocol-http": "^5.3.7", "@smithy/signature-v4": "^5.3.7", "@smithy/smithy-client": "^4.10.2", "@smithy/types": "^4.11.0", "@smithy/util-config-provider": "^4.2.0", "@smithy/util-middleware": "^4.2.7", "@smithy/util-stream": "^4.5.8", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-5B2qY2nR2LYpxoQP0xUum5A1UNvH2JQpLHDH1nWFNF/XetV7ipFHksMxPNhtJJ6ARaWhQIDXfOUj0jcnkJxXUg=="],
+
+    "@aws-sdk/middleware-ssec": ["@aws-sdk/middleware-ssec@3.957.0", "", { "dependencies": { "@aws-sdk/types": "3.957.0", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-qwkmrK0lizdjNt5qxl4tHYfASh8DFpHXM1iDVo+qHe+zuslfMqQEGRkzxS8tJq/I+8F0c6v3IKOveKJAfIvfqQ=="],
+
+    "@aws-sdk/middleware-user-agent": ["@aws-sdk/middleware-user-agent@3.957.0", "", { "dependencies": { "@aws-sdk/core": "3.957.0", "@aws-sdk/types": "3.957.0", "@aws-sdk/util-endpoints": "3.957.0", "@smithy/core": "^3.20.0", "@smithy/protocol-http": "^5.3.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-50vcHu96XakQnIvlKJ1UoltrFODjsq2KvtTgHiPFteUS884lQnK5VC/8xd1Msz/1ONpLMzdCVproCQqhDTtMPQ=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.958.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "3.957.0", "@aws-sdk/middleware-host-header": "3.957.0", "@aws-sdk/middleware-logger": "3.957.0", "@aws-sdk/middleware-recursion-detection": "3.957.0", "@aws-sdk/middleware-user-agent": "3.957.0", "@aws-sdk/region-config-resolver": "3.957.0", "@aws-sdk/types": "3.957.0", "@aws-sdk/util-endpoints": "3.957.0", "@aws-sdk/util-user-agent-browser": "3.957.0", "@aws-sdk/util-user-agent-node": "3.957.0", "@smithy/config-resolver": "^4.4.5", "@smithy/core": "^3.20.0", "@smithy/fetch-http-handler": "^5.3.8", "@smithy/hash-node": "^4.2.7", "@smithy/invalid-dependency": "^4.2.7", "@smithy/middleware-content-length": "^4.2.7", "@smithy/middleware-endpoint": "^4.4.1", "@smithy/middleware-retry": "^4.4.17", "@smithy/middleware-serde": "^4.2.8", "@smithy/middleware-stack": "^4.2.7", "@smithy/node-config-provider": "^4.3.7", "@smithy/node-http-handler": "^4.4.7", "@smithy/protocol-http": "^5.3.7", "@smithy/smithy-client": "^4.10.2", "@smithy/types": "^4.11.0", "@smithy/url-parser": "^4.2.7", "@smithy/util-base64": "^4.3.0", "@smithy/util-body-length-browser": "^4.2.0", "@smithy/util-body-length-node": "^4.2.1", "@smithy/util-defaults-mode-browser": "^4.3.16", "@smithy/util-defaults-mode-node": "^4.2.19", "@smithy/util-endpoints": "^3.2.7", "@smithy/util-middleware": "^4.2.7", "@smithy/util-retry": "^4.2.7", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-/KuCcS8b5TpQXkYOrPLYytrgxBhv81+5pChkOlhegbeHttjM69pyUpQVJqyfDM/A7wPLnDrzCAnk4zaAOkY0Nw=="],
+
+    "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.957.0", "", { "dependencies": { "@aws-sdk/types": "3.957.0", "@smithy/config-resolver": "^4.4.5", "@smithy/node-config-provider": "^4.3.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-V8iY3blh8l2iaOqXWW88HbkY5jDoWjH56jonprG/cpyqqCnprvpMUZWPWYJoI8rHRf2bqzZeql1slxG6EnKI7A=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.957.0", "", { "dependencies": { "@aws-sdk/middleware-sdk-s3": "3.957.0", "@aws-sdk/types": "3.957.0", "@smithy/protocol-http": "^5.3.7", "@smithy/signature-v4": "^5.3.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-t6UfP1xMUigMMzHcb7vaZcjv7dA2DQkk9C/OAP1dKyrE0vb4lFGDaTApi17GN6Km9zFxJthEMUbBc7DL0hq1Bg=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.958.0", "", { "dependencies": { "@aws-sdk/core": "3.957.0", "@aws-sdk/nested-clients": "3.958.0", "@aws-sdk/types": "3.957.0", "@smithy/property-provider": "^4.2.7", "@smithy/shared-ini-file-loader": "^4.4.2", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-UCj7lQXODduD1myNJQkV+LYcGYJ9iiMggR8ow8Hva1g3A/Na5imNXzz6O67k7DAee0TYpy+gkNw+SizC6min8Q=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.957.0", "", { "dependencies": { "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-wzWC2Nrt859ABk6UCAVY/WYEbAd7FjkdrQL6m24+tfmWYDNRByTJ9uOgU/kw9zqLCAwb//CPvrJdhqjTznWXAg=="],
+
+    "@aws-sdk/util-arn-parser": ["@aws-sdk/util-arn-parser@3.957.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Aj6m+AyrhWyg8YQ4LDPg2/gIfGHCEcoQdBt5DeSFogN5k9mmJPOJ+IAmNSWmWRjpOxEy6eY813RNDI6qS97M0g=="],
+
+    "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.957.0", "", { "dependencies": { "@aws-sdk/types": "3.957.0", "@smithy/types": "^4.11.0", "@smithy/url-parser": "^4.2.7", "@smithy/util-endpoints": "^3.2.7", "tslib": "^2.6.2" } }, "sha512-xwF9K24mZSxcxKS3UKQFeX/dPYkEps9wF1b+MGON7EvnbcucrJGyQyK1v1xFPn1aqXkBTFi+SZaMRx5E5YCVFw=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.957.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-nhmgKHnNV9K+i9daumaIz8JTLsIIML9PE/HUks5liyrjUzenjW/aHoc7WJ9/Td/gPZtayxFnXQSJRb/fDlBuJw=="],
+
+    "@aws-sdk/util-user-agent-browser": ["@aws-sdk/util-user-agent-browser@3.957.0", "", { "dependencies": { "@aws-sdk/types": "3.957.0", "@smithy/types": "^4.11.0", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-exueuwxef0lUJRnGaVkNSC674eAiWU07ORhxBnevFFZEKisln+09Qrtw823iyv5I1N8T+wKfh95xvtWQrNKNQw=="],
+
+    "@aws-sdk/util-user-agent-node": ["@aws-sdk/util-user-agent-node@3.957.0", "", { "dependencies": { "@aws-sdk/middleware-user-agent": "3.957.0", "@aws-sdk/types": "3.957.0", "@smithy/node-config-provider": "^4.3.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" }, "peerDependencies": { "aws-crt": ">=1.0.0" }, "optionalPeers": ["aws-crt"] }, "sha512-ycbYCwqXk4gJGp0Oxkzf2KBeeGBdTxz559D41NJP8FlzSej1Gh7Rk40Zo6AyTfsNWkrl/kVi1t937OIzC5t+9Q=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.957.0", "", { "dependencies": { "@smithy/types": "^4.11.0", "fast-xml-parser": "5.2.5", "tslib": "^2.6.2" } }, "sha512-Ai5iiQqS8kJ5PjzMhWcLKN0G2yasAkvpnPlq2EnqlIMdB48HsizElt62qcktdxp4neRMyGkFq4NzgmDbXnhRiA=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.2", "", {}, "sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.26.2", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.25.9", "js-tokens": "^4.0.0", "picocolors": "^1.0.0" } }, "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ=="],
 
@@ -195,6 +291,8 @@
 
     "@ferrucc-io/emoji-picker-demo": ["@ferrucc-io/emoji-picker-demo@workspace:demo"],
 
+    "@ferrucc-io/emoji-picker-server": ["@ferrucc-io/emoji-picker-server@workspace:packages/server"],
+
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.0.0", "", { "dependencies": { "@types/node": "^20.0.0", "happy-dom": "^20.0.0" } }, "sha512-Q5vFZERQ8mYLZSpphoutH1wEdf/QqMA8z1C7f5/huJARJ2LHOoC/cDk+0sloTiM0CeGXuNPI7nr8GAbFHoSQmA=="],
 
     "@humanwhocodes/config-array": ["@humanwhocodes/config-array@0.13.0", "", { "dependencies": { "@humanwhocodes/object-schema": "^2.0.3", "debug": "^4.3.1", "minimatch": "^3.0.5" } }, "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw=="],
@@ -287,6 +385,8 @@
 
     "@oxlint/win32-x64": ["@oxlint/win32-x64@0.15.8", "", { "os": "win32", "cpu": "x64" }, "sha512-dH0W6OOQb5G0CDuT81nKUbAnTfo2SdYeRKodEYUBrXh6pO3YZ8iMl7G1N6TWDO4XBo8nE685/hXDN64e30PO5g=="],
 
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.38", "", {}, "sha512-N/ICGKleNhA5nc9XXQG/kkKHJ7S55u0x0XUJbbkmdCnFuoRkM1Il12q9q0eX19+M7KKUEPw/daUPIRnxhcxAIw=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.52.4", "", { "os": "android", "cpu": "arm" }, "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA=="],
@@ -339,6 +439,108 @@
 
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
+    "@smithy/abort-controller": ["@smithy/abort-controller@4.2.7", "", { "dependencies": { "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-rzMY6CaKx2qxrbYbqjXWS0plqEy7LOdKHS0bg4ixJ6aoGDPNUcLWk/FRNuCILh7GKLG9TFUXYYeQQldMBBwuyw=="],
+
+    "@smithy/chunked-blob-reader": ["@smithy/chunked-blob-reader@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WmU0TnhEAJLWvfSeMxBNe5xtbselEO8+4wG0NtZeL8oR21WgH1xiO37El+/Y+H/Ie4SCwBy3MxYWmOYaGgZueA=="],
+
+    "@smithy/chunked-blob-reader-native": ["@smithy/chunked-blob-reader-native@4.2.1", "", { "dependencies": { "@smithy/util-base64": "^4.3.0", "tslib": "^2.6.2" } }, "sha512-lX9Ay+6LisTfpLid2zZtIhSEjHMZoAR5hHCR4H7tBz/Zkfr5ea8RcQ7Tk4mi0P76p4cN+Btz16Ffno7YHpKXnQ=="],
+
+    "@smithy/config-resolver": ["@smithy/config-resolver@4.4.5", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.7", "@smithy/types": "^4.11.0", "@smithy/util-config-provider": "^4.2.0", "@smithy/util-endpoints": "^3.2.7", "@smithy/util-middleware": "^4.2.7", "tslib": "^2.6.2" } }, "sha512-HAGoUAFYsUkoSckuKbCPayECeMim8pOu+yLy1zOxt1sifzEbrsRpYa+mKcMdiHKMeiqOibyPG0sFJnmaV/OGEg=="],
+
+    "@smithy/core": ["@smithy/core@3.20.0", "", { "dependencies": { "@smithy/middleware-serde": "^4.2.8", "@smithy/protocol-http": "^5.3.7", "@smithy/types": "^4.11.0", "@smithy/util-base64": "^4.3.0", "@smithy/util-body-length-browser": "^4.2.0", "@smithy/util-middleware": "^4.2.7", "@smithy/util-stream": "^4.5.8", "@smithy/util-utf8": "^4.2.0", "@smithy/uuid": "^1.1.0", "tslib": "^2.6.2" } }, "sha512-WsSHCPq/neD5G/MkK4csLI5Y5Pkd9c1NMfpYEKeghSGaD4Ja1qLIohRQf2D5c1Uy5aXp76DeKHkzWZ9KAlHroQ=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.2.7", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.7", "@smithy/property-provider": "^4.2.7", "@smithy/types": "^4.11.0", "@smithy/url-parser": "^4.2.7", "tslib": "^2.6.2" } }, "sha512-CmduWdCiILCRNbQWFR0OcZlUPVtyE49Sr8yYL0rZQ4D/wKxiNzBNS/YHemvnbkIWj623fplgkexUd/c9CAKdoA=="],
+
+    "@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.2.7", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.11.0", "@smithy/util-hex-encoding": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-DrpkEoM3j9cBBWhufqBwnbbn+3nf1N9FP6xuVJ+e220jbactKuQgaZwjwP5CP1t+O94brm2JgVMD2atMGX3xIQ=="],
+
+    "@smithy/eventstream-serde-browser": ["@smithy/eventstream-serde-browser@4.2.7", "", { "dependencies": { "@smithy/eventstream-serde-universal": "^4.2.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-ujzPk8seYoDBmABDE5YqlhQZAXLOrtxtJLrbhHMKjBoG5b4dK4i6/mEU+6/7yXIAkqOO8sJ6YxZl+h0QQ1IJ7g=="],
+
+    "@smithy/eventstream-serde-config-resolver": ["@smithy/eventstream-serde-config-resolver@4.3.7", "", { "dependencies": { "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-x7BtAiIPSaNaWuzm24Q/mtSkv+BrISO/fmheiJ39PKRNH3RmH2Hph/bUKSOBOBC9unqfIYDhKTHwpyZycLGPVQ=="],
+
+    "@smithy/eventstream-serde-node": ["@smithy/eventstream-serde-node@4.2.7", "", { "dependencies": { "@smithy/eventstream-serde-universal": "^4.2.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-roySCtHC5+pQq5lK4be1fZ/WR6s/AxnPaLfCODIPArtN2du8s5Ot4mKVK3pPtijL/L654ws592JHJ1PbZFF6+A=="],
+
+    "@smithy/eventstream-serde-universal": ["@smithy/eventstream-serde-universal@4.2.7", "", { "dependencies": { "@smithy/eventstream-codec": "^4.2.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-QVD+g3+icFkThoy4r8wVFZMsIP08taHVKjE6Jpmz8h5CgX/kk6pTODq5cht0OMtcapUx+xrPzUTQdA+TmO0m1g=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.3.8", "", { "dependencies": { "@smithy/protocol-http": "^5.3.7", "@smithy/querystring-builder": "^4.2.7", "@smithy/types": "^4.11.0", "@smithy/util-base64": "^4.3.0", "tslib": "^2.6.2" } }, "sha512-h/Fi+o7mti4n8wx1SR6UHWLaakwHRx29sizvp8OOm7iqwKGFneT06GCSFhml6Bha5BT6ot5pj3CYZnCHhGC2Rg=="],
+
+    "@smithy/hash-blob-browser": ["@smithy/hash-blob-browser@4.2.8", "", { "dependencies": { "@smithy/chunked-blob-reader": "^5.2.0", "@smithy/chunked-blob-reader-native": "^4.2.1", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-07InZontqsM1ggTCPSRgI7d8DirqRrnpL7nIACT4PW0AWrgDiHhjGZzbAE5UtRSiU0NISGUYe7/rri9ZeWyDpw=="],
+
+    "@smithy/hash-node": ["@smithy/hash-node@4.2.7", "", { "dependencies": { "@smithy/types": "^4.11.0", "@smithy/util-buffer-from": "^4.2.0", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-PU/JWLTBCV1c8FtB8tEFnY4eV1tSfBc7bDBADHfn1K+uRbPgSJ9jnJp0hyjiFN2PMdPzxsf1Fdu0eo9fJ760Xw=="],
+
+    "@smithy/hash-stream-node": ["@smithy/hash-stream-node@4.2.7", "", { "dependencies": { "@smithy/types": "^4.11.0", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-ZQVoAwNYnFMIbd4DUc517HuwNelJUY6YOzwqrbcAgCnVn+79/OK7UjwA93SPpdTOpKDVkLIzavWm/Ck7SmnDPQ=="],
+
+    "@smithy/invalid-dependency": ["@smithy/invalid-dependency@4.2.7", "", { "dependencies": { "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-ncvgCr9a15nPlkhIUx3CU4d7E7WEuVJOV7fS7nnK2hLtPK9tYRBkMHQbhXU1VvvKeBm/O0x26OEoBq+ngFpOEQ=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@4.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ=="],
+
+    "@smithy/md5-js": ["@smithy/md5-js@4.2.7", "", { "dependencies": { "@smithy/types": "^4.11.0", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-Wv6JcUxtOLTnxvNjDnAiATUsk8gvA6EeS8zzHig07dotpByYsLot+m0AaQEniUBjx97AC41MQR4hW0baraD1Xw=="],
+
+    "@smithy/middleware-content-length": ["@smithy/middleware-content-length@4.2.7", "", { "dependencies": { "@smithy/protocol-http": "^5.3.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-GszfBfCcvt7kIbJ41LuNa5f0wvQCHhnGx/aDaZJCCT05Ld6x6U2s0xsc/0mBFONBZjQJp2U/0uSJ178OXOwbhg=="],
+
+    "@smithy/middleware-endpoint": ["@smithy/middleware-endpoint@4.4.1", "", { "dependencies": { "@smithy/core": "^3.20.0", "@smithy/middleware-serde": "^4.2.8", "@smithy/node-config-provider": "^4.3.7", "@smithy/shared-ini-file-loader": "^4.4.2", "@smithy/types": "^4.11.0", "@smithy/url-parser": "^4.2.7", "@smithy/util-middleware": "^4.2.7", "tslib": "^2.6.2" } }, "sha512-gpLspUAoe6f1M6H0u4cVuFzxZBrsGZmjx2O9SigurTx4PbntYa4AJ+o0G0oGm1L2oSX6oBhcGHwrfJHup2JnJg=="],
+
+    "@smithy/middleware-retry": ["@smithy/middleware-retry@4.4.17", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.7", "@smithy/protocol-http": "^5.3.7", "@smithy/service-error-classification": "^4.2.7", "@smithy/smithy-client": "^4.10.2", "@smithy/types": "^4.11.0", "@smithy/util-middleware": "^4.2.7", "@smithy/util-retry": "^4.2.7", "@smithy/uuid": "^1.1.0", "tslib": "^2.6.2" } }, "sha512-MqbXK6Y9uq17h+4r0ogu/sBT6V/rdV+5NvYL7ZV444BKfQygYe8wAhDrVXagVebN6w2RE0Fm245l69mOsPGZzg=="],
+
+    "@smithy/middleware-serde": ["@smithy/middleware-serde@4.2.8", "", { "dependencies": { "@smithy/protocol-http": "^5.3.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-8rDGYen5m5+NV9eHv9ry0sqm2gI6W7mc1VSFMtn6Igo25S507/HaOX9LTHAS2/J32VXD0xSzrY0H5FJtOMS4/w=="],
+
+    "@smithy/middleware-stack": ["@smithy/middleware-stack@4.2.7", "", { "dependencies": { "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-bsOT0rJ+HHlZd9crHoS37mt8qRRN/h9jRve1SXUhVbkRzu0QaNYZp1i1jha4n098tsvROjcwfLlfvcFuJSXEsw=="],
+
+    "@smithy/node-config-provider": ["@smithy/node-config-provider@4.3.7", "", { "dependencies": { "@smithy/property-provider": "^4.2.7", "@smithy/shared-ini-file-loader": "^4.4.2", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-7r58wq8sdOcrwWe+klL9y3bc4GW1gnlfnFOuL7CXa7UzfhzhxKuzNdtqgzmTV+53lEp9NXh5hY/S4UgjLOzPfw=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.4.7", "", { "dependencies": { "@smithy/abort-controller": "^4.2.7", "@smithy/protocol-http": "^5.3.7", "@smithy/querystring-builder": "^4.2.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-NELpdmBOO6EpZtWgQiHjoShs1kmweaiNuETUpuup+cmm/xJYjT4eUjfhrXRP4jCOaAsS3c3yPsP3B+K+/fyPCQ=="],
+
+    "@smithy/property-provider": ["@smithy/property-provider@4.2.7", "", { "dependencies": { "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-jmNYKe9MGGPoSl/D7JDDs1C8b3dC8f/w78LbaVfoTtWy4xAd5dfjaFG9c9PWPihY4ggMQNQSMtzU77CNgAJwmA=="],
+
+    "@smithy/protocol-http": ["@smithy/protocol-http@5.3.7", "", { "dependencies": { "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-1r07pb994I20dD/c2seaZhoCuNYm0rWrvBxhCQ70brNh11M5Ml2ew6qJVo0lclB3jMIXirD4s2XRXRe7QEi0xA=="],
+
+    "@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.7", "", { "dependencies": { "@smithy/types": "^4.11.0", "@smithy/util-uri-escape": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-eKONSywHZxK4tBxe2lXEysh8wbBdvDWiA+RIuaxZSgCMmA0zMgoDpGLJhnyj+c0leOQprVnXOmcB4m+W9Rw7sg=="],
+
+    "@smithy/querystring-parser": ["@smithy/querystring-parser@4.2.7", "", { "dependencies": { "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-3X5ZvzUHmlSTHAXFlswrS6EGt8fMSIxX/c3Rm1Pni3+wYWB6cjGocmRIoqcQF9nU5OgGmL0u7l9m44tSUpfj9w=="],
+
+    "@smithy/service-error-classification": ["@smithy/service-error-classification@4.2.7", "", { "dependencies": { "@smithy/types": "^4.11.0" } }, "sha512-YB7oCbukqEb2Dlh3340/8g8vNGbs/QsNNRms+gv3N2AtZz9/1vSBx6/6tpwQpZMEJFs7Uq8h4mmOn48ZZ72MkA=="],
+
+    "@smithy/shared-ini-file-loader": ["@smithy/shared-ini-file-loader@4.4.2", "", { "dependencies": { "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-M7iUUff/KwfNunmrgtqBfvZSzh3bmFgv/j/t1Y1dQ+8dNo34br1cqVEqy6v0mYEgi0DkGO7Xig0AnuOaEGVlcg=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.3.7", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.0", "@smithy/protocol-http": "^5.3.7", "@smithy/types": "^4.11.0", "@smithy/util-hex-encoding": "^4.2.0", "@smithy/util-middleware": "^4.2.7", "@smithy/util-uri-escape": "^4.2.0", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-9oNUlqBlFZFOSdxgImA6X5GFuzE7V2H7VG/7E70cdLhidFbdtvxxt81EHgykGK5vq5D3FafH//X+Oy31j3CKOg=="],
+
+    "@smithy/smithy-client": ["@smithy/smithy-client@4.10.2", "", { "dependencies": { "@smithy/core": "^3.20.0", "@smithy/middleware-endpoint": "^4.4.1", "@smithy/middleware-stack": "^4.2.7", "@smithy/protocol-http": "^5.3.7", "@smithy/types": "^4.11.0", "@smithy/util-stream": "^4.5.8", "tslib": "^2.6.2" } }, "sha512-D5z79xQWpgrGpAHb054Fn2CCTQZpog7JELbVQ6XAvXs5MNKWf28U9gzSBlJkOyMl9LA1TZEjRtwvGXfP0Sl90g=="],
+
+    "@smithy/types": ["@smithy/types@4.11.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-mlrmL0DRDVe3mNrjTcVcZEgkFmufITfUAPBEA+AHYiIeYyJebso/He1qLbP3PssRe22KUzLRpQSdBPbXdgZ2VA=="],
+
+    "@smithy/url-parser": ["@smithy/url-parser@4.2.7", "", { "dependencies": { "@smithy/querystring-parser": "^4.2.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-/RLtVsRV4uY3qPWhBDsjwahAtt3x2IsMGnP5W1b2VZIe+qgCqkLxI1UOHDZp1Q1QSOrdOR32MF3Ph2JfWT1VHg=="],
+
+    "@smithy/util-base64": ["@smithy/util-base64@4.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.0", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ=="],
+
+    "@smithy/util-body-length-browser": ["@smithy/util-body-length-browser@4.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg=="],
+
+    "@smithy/util-body-length-node": ["@smithy/util-body-length-node@4.2.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@4.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew=="],
+
+    "@smithy/util-config-provider": ["@smithy/util-config-provider@4.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q=="],
+
+    "@smithy/util-defaults-mode-browser": ["@smithy/util-defaults-mode-browser@4.3.16", "", { "dependencies": { "@smithy/property-provider": "^4.2.7", "@smithy/smithy-client": "^4.10.2", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-/eiSP3mzY3TsvUOYMeL4EqUX6fgUOj2eUOU4rMMgVbq67TiRLyxT7Xsjxq0bW3OwuzK009qOwF0L2OgJqperAQ=="],
+
+    "@smithy/util-defaults-mode-node": ["@smithy/util-defaults-mode-node@4.2.19", "", { "dependencies": { "@smithy/config-resolver": "^4.4.5", "@smithy/credential-provider-imds": "^4.2.7", "@smithy/node-config-provider": "^4.3.7", "@smithy/property-provider": "^4.2.7", "@smithy/smithy-client": "^4.10.2", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-3a4+4mhf6VycEJyHIQLypRbiwG6aJvbQAeRAVXydMmfweEPnLLabRbdyo/Pjw8Rew9vjsh5WCdhmDaHkQnhhhA=="],
+
+    "@smithy/util-endpoints": ["@smithy/util-endpoints@3.2.7", "", { "dependencies": { "@smithy/node-config-provider": "^4.3.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-s4ILhyAvVqhMDYREeTS68R43B1V5aenV5q/V1QpRQJkCXib5BPRo4s7uNdzGtIKxaPHCfU/8YkvPAEvTpxgspg=="],
+
+    "@smithy/util-hex-encoding": ["@smithy/util-hex-encoding@4.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw=="],
+
+    "@smithy/util-middleware": ["@smithy/util-middleware@4.2.7", "", { "dependencies": { "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-i1IkpbOae6NvIKsEeLLM9/2q4X+M90KV3oCFgWQI4q0Qz+yUZvsr+gZPdAEAtFhWQhAHpTsJO8DRJPuwVyln+w=="],
+
+    "@smithy/util-retry": ["@smithy/util-retry@4.2.7", "", { "dependencies": { "@smithy/service-error-classification": "^4.2.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-SvDdsQyF5CIASa4EYVT02LukPHVzAgUA4kMAuZ97QJc2BpAqZfA4PINB8/KOoCXEw9tsuv/jQjMeaHFvxdLNGg=="],
+
+    "@smithy/util-stream": ["@smithy/util-stream@4.5.8", "", { "dependencies": { "@smithy/fetch-http-handler": "^5.3.8", "@smithy/node-http-handler": "^4.4.7", "@smithy/types": "^4.11.0", "@smithy/util-base64": "^4.3.0", "@smithy/util-buffer-from": "^4.2.0", "@smithy/util-hex-encoding": "^4.2.0", "@smithy/util-utf8": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-ZnnBhTapjM0YPGUSmOs0Mcg/Gg87k503qG4zU2v/+Js2Gu+daKOJMeqcQns8ajepY8tgzzfYxl6kQyZKml6O2w=="],
+
+    "@smithy/util-uri-escape": ["@smithy/util-uri-escape@4.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@4.2.0", "", { "dependencies": { "@smithy/util-buffer-from": "^4.2.0", "tslib": "^2.6.2" } }, "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw=="],
+
+    "@smithy/util-waiter": ["@smithy/util-waiter@4.2.7", "", { "dependencies": { "@smithy/abort-controller": "^4.2.7", "@smithy/types": "^4.11.0", "tslib": "^2.6.2" } }, "sha512-vHJFXi9b7kUEpHWUCY3Twl+9NPOZvQ0SAi+Ewtn48mbiJk4JY9MZmKQjGB4SCvVb9WPiSphZJYY6RIbs+grrzw=="],
+
+    "@smithy/uuid": ["@smithy/uuid@1.1.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw=="],
+
     "@tailwindcss/node": ["@tailwindcss/node@4.0.0", "", { "dependencies": { "enhanced-resolve": "^5.18.0", "jiti": "^2.4.2", "tailwindcss": "4.0.0" } }, "sha512-tfG2uBvo6j6kDIPmntxwXggCOZAt7SkpAXJ6pTIYirNdk5FBqh/CZZ9BZPpgcl/tNFLs6zc4yghM76sqiELG9g=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.0.0", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.0.0", "@tailwindcss/oxide-darwin-arm64": "4.0.0", "@tailwindcss/oxide-darwin-x64": "4.0.0", "@tailwindcss/oxide-freebsd-x64": "4.0.0", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.0.0", "@tailwindcss/oxide-linux-arm64-gnu": "4.0.0", "@tailwindcss/oxide-linux-arm64-musl": "4.0.0", "@tailwindcss/oxide-linux-x64-gnu": "4.0.0", "@tailwindcss/oxide-linux-x64-musl": "4.0.0", "@tailwindcss/oxide-win32-arm64-msvc": "4.0.0", "@tailwindcss/oxide-win32-x64-msvc": "4.0.0" } }, "sha512-W3FjpJgy4VV1JiL7iBYDf2n/WkeDg1Il+0Q7eWnqPyvkPPCo/Mbwc5BiaT7dfBNV6tQKAhVE34rU5xl8pSl50w=="],
@@ -387,7 +589,7 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.20.6", "", { "dependencies": { "@babel/types": "^7.20.7" } }, "sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg=="],
 
-    "@types/bun": ["@types/bun@1.3.4", "", { "dependencies": { "bun-types": "1.3.4" } }, "sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA=="],
+    "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -469,13 +671,15 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "bowser": ["bowser@2.13.1", "", {}, "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw=="],
+
     "brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.24.4", "", { "dependencies": { "caniuse-lite": "^1.0.30001688", "electron-to-chromium": "^1.5.73", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.1" }, "bin": { "browserslist": "cli.js" } }, "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A=="],
 
-    "bun-types": ["bun-types@1.3.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ=="],
+    "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
@@ -493,9 +697,13 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
 
     "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 
@@ -599,6 +807,8 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
+    "fast-xml-parser": ["fast-xml-parser@5.2.5", "", { "dependencies": { "strnum": "^2.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ=="],
+
     "fastq": ["fastq@1.18.0", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
@@ -692,6 +902,8 @@
     "is-arguments": ["is-arguments@1.2.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA=="],
 
     "is-array-buffer": ["is-array-buffer@3.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A=="],
+
+    "is-arrayish": ["is-arrayish@0.3.4", "", {}, "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="],
 
     "is-async-function": ["is-async-function@2.1.1", "", { "dependencies": { "async-function": "^1.0.0", "call-bound": "^1.0.3", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ=="],
 
@@ -877,6 +1089,10 @@
 
     "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
     "possible-typed-array-names": ["possible-typed-array-names@1.0.0", "", {}, "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
@@ -953,6 +1169,8 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "simple-swizzle": ["simple-swizzle@0.2.4", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw=="],
+
     "skin-tone": ["skin-tone@2.0.0", "", { "dependencies": { "unicode-emoji-modifier-base": "^1.0.0" } }, "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA=="],
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
@@ -978,6 +1196,8 @@
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
     "strip-outer": ["strip-outer@1.0.1", "", { "dependencies": { "escape-string-regexp": "^1.0.2" } }, "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg=="],
+
+    "strnum": ["strnum@2.1.2", "", {}, "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -1057,6 +1277,12 @@
 
     "@ampproject/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
 
+    "@aws-crypto/sha1-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
     "@babel/core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@babel/helper-module-transforms/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.27.1", "", {}, "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="],
@@ -1072,6 +1298,8 @@
     "@ferrucc-io/emoji-picker-demo/@typescript-eslint/parser": ["@typescript-eslint/parser@6.21.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "6.21.0", "@typescript-eslint/types": "6.21.0", "@typescript-eslint/typescript-estree": "6.21.0", "@typescript-eslint/visitor-keys": "6.21.0", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^7.0.0 || ^8.0.0" } }, "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ=="],
 
     "@ferrucc-io/emoji-picker-demo/@vitejs/plugin-react": ["@vitejs/plugin-react@4.3.4", "", { "dependencies": { "@babel/core": "^7.26.0", "@babel/plugin-transform-react-jsx-self": "^7.25.9", "@babel/plugin-transform-react-jsx-source": "^7.25.9", "@types/babel__core": "^7.20.5", "react-refresh": "^0.14.2" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0" } }, "sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp": ["sharp@0.33.5", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.6.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.33.5", "@img/sharp-darwin-x64": "0.33.5", "@img/sharp-libvips-darwin-arm64": "1.0.4", "@img/sharp-libvips-darwin-x64": "1.0.4", "@img/sharp-libvips-linux-arm": "1.0.5", "@img/sharp-libvips-linux-arm64": "1.0.4", "@img/sharp-libvips-linux-s390x": "1.0.4", "@img/sharp-libvips-linux-x64": "1.0.4", "@img/sharp-libvips-linuxmusl-arm64": "1.0.4", "@img/sharp-libvips-linuxmusl-x64": "1.0.4", "@img/sharp-linux-arm": "0.33.5", "@img/sharp-linux-arm64": "0.33.5", "@img/sharp-linux-s390x": "0.33.5", "@img/sharp-linux-x64": "0.33.5", "@img/sharp-linuxmusl-arm64": "0.33.5", "@img/sharp-linuxmusl-x64": "0.33.5", "@img/sharp-wasm32": "0.33.5", "@img/sharp-win32-ia32": "0.33.5", "@img/sharp-win32-x64": "0.33.5" } }, "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw=="],
 
     "@tailwindcss/node/tailwindcss": ["tailwindcss@4.0.0", "", {}, "sha512-ULRPI3A+e39T7pSaf1xoi58AqqJxVCLg8F/uM5A3FadUbnyDTgltVnXJvdkTjwCOGA6NazqHVcwPJC5h2vRYVQ=="],
 
@@ -1129,6 +1357,8 @@
 
     "pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
@@ -1140,6 +1370,12 @@
     "trim-repeated/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
     "vite-plugin-oxlint/vite": ["vite@6.0.11", "", { "dependencies": { "esbuild": "^0.24.2", "postcss": "^8.4.49", "rollup": "^4.23.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg=="],
+
+    "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
     "@babel/core/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.27.1", "", {}, "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="],
 
@@ -1175,6 +1411,46 @@
 
     "@ferrucc-io/emoji-picker-demo/@vitejs/plugin-react/vite": ["vite@5.4.20", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g=="],
 
+    "@ferrucc-io/emoji-picker-server/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.0.4" }, "os": "darwin", "cpu": "x64" }, "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.0.5", "", { "os": "linux", "cpu": "arm" }, "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.0.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.0.5" }, "os": "linux", "cpu": "arm" }, "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.0.4" }, "os": "linux", "cpu": "s390x" }, "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.33.5", "", { "dependencies": { "@emnapi/runtime": "^1.2.0" }, "cpu": "none" }, "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.33.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
+
+    "@ferrucc-io/emoji-picker-server/sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
     "@tailwindcss/vite/vite/esbuild": ["esbuild@0.24.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.24.2", "@esbuild/android-arm": "0.24.2", "@esbuild/android-arm64": "0.24.2", "@esbuild/android-x64": "0.24.2", "@esbuild/darwin-arm64": "0.24.2", "@esbuild/darwin-x64": "0.24.2", "@esbuild/freebsd-arm64": "0.24.2", "@esbuild/freebsd-x64": "0.24.2", "@esbuild/linux-arm": "0.24.2", "@esbuild/linux-arm64": "0.24.2", "@esbuild/linux-ia32": "0.24.2", "@esbuild/linux-loong64": "0.24.2", "@esbuild/linux-mips64el": "0.24.2", "@esbuild/linux-ppc64": "0.24.2", "@esbuild/linux-riscv64": "0.24.2", "@esbuild/linux-s390x": "0.24.2", "@esbuild/linux-x64": "0.24.2", "@esbuild/netbsd-arm64": "0.24.2", "@esbuild/netbsd-x64": "0.24.2", "@esbuild/openbsd-arm64": "0.24.2", "@esbuild/openbsd-x64": "0.24.2", "@esbuild/sunos-x64": "0.24.2", "@esbuild/win32-arm64": "0.24.2", "@esbuild/win32-ia32": "0.24.2", "@esbuild/win32-x64": "0.24.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA=="],
 
     "@tailwindcss/vite/vite/postcss": ["postcss@8.5.1", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ=="],
@@ -1202,6 +1478,12 @@
     "vite-plugin-oxlint/vite/postcss": ["postcss@8.5.1", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ=="],
 
     "vite-plugin-oxlint/vite/rollup": ["rollup@4.32.0", "", { "dependencies": { "@types/estree": "1.0.6" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.32.0", "@rollup/rollup-android-arm64": "4.32.0", "@rollup/rollup-darwin-arm64": "4.32.0", "@rollup/rollup-darwin-x64": "4.32.0", "@rollup/rollup-freebsd-arm64": "4.32.0", "@rollup/rollup-freebsd-x64": "4.32.0", "@rollup/rollup-linux-arm-gnueabihf": "4.32.0", "@rollup/rollup-linux-arm-musleabihf": "4.32.0", "@rollup/rollup-linux-arm64-gnu": "4.32.0", "@rollup/rollup-linux-arm64-musl": "4.32.0", "@rollup/rollup-linux-loongarch64-gnu": "4.32.0", "@rollup/rollup-linux-powerpc64le-gnu": "4.32.0", "@rollup/rollup-linux-riscv64-gnu": "4.32.0", "@rollup/rollup-linux-s390x-gnu": "4.32.0", "@rollup/rollup-linux-x64-gnu": "4.32.0", "@rollup/rollup-linux-x64-musl": "4.32.0", "@rollup/rollup-win32-arm64-msvc": "4.32.0", "@rollup/rollup-win32-ia32-msvc": "4.32.0", "@rollup/rollup-win32-x64-msvc": "4.32.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-JmrhfQR31Q4AuNBjjAX4s+a/Pu/Q8Q9iwjWBsjRH1q52SPFE2NqRMK6fUZKKnvKO6id+h7JIRf0oYsph53eATg=="],
+
+    "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
     "@ferrucc-io/emoji-picker-demo/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@6.21.0", "", {}, "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg=="],
 

--- a/e2e/emoji-picker.spec.ts
+++ b/e2e/emoji-picker.spec.ts
@@ -1,0 +1,222 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Selecting emojis by click', () => {
+  test('clicking an emoji updates the hero section', async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for the emoji picker to render
+    const emojiButton = page.locator('button[data-emoji]').first();
+    await emojiButton.waitFor();
+
+    // Get the emoji text from the button
+    const emoji = await emojiButton.getAttribute('data-emoji');
+    expect(emoji).toBeTruthy();
+
+    // Click the emoji
+    await emojiButton.click();
+
+    // Verify the hero section shows the selected emoji
+    const heroEmoji = page.locator('.text-6xl');
+    await expect(heroEmoji).toHaveText(emoji!);
+  });
+
+  test('clicking different emojis updates selection', async ({ page }) => {
+    await page.goto('/');
+
+    await page.locator('button[data-emoji]').first().waitFor();
+
+    // Click the third emoji button
+    const thirdEmoji = page.locator('button[data-emoji]').nth(2);
+    const emojiValue = await thirdEmoji.getAttribute('data-emoji');
+    await thirdEmoji.click();
+
+    const heroEmoji = page.locator('.text-6xl');
+    await expect(heroEmoji).toHaveText(emojiValue!);
+  });
+});
+
+test.describe('Keyboard navigation', () => {
+  test('arrow keys move selection and Enter selects', async ({ page }) => {
+    await page.goto('/');
+
+    await page.locator('button[data-emoji]').first().waitFor();
+
+    // The hero starts with the default "⌘" emoji
+    const heroEmoji = page.locator('.text-6xl');
+    await expect(heroEmoji).toHaveText('⌘');
+
+    // Press ArrowDown to initialize keyboard selection at the first emoji
+    await page.keyboard.press('ArrowDown');
+
+    // An emoji should now have the selected background class
+    const selectedButton = page.locator(
+      'button[data-emoji].bg-\\[var\\(--emoji-hover-color\\)\\]'
+    );
+    await expect(selectedButton).toBeVisible();
+
+    // Press ArrowRight to move to the next emoji
+    await page.keyboard.press('ArrowRight');
+
+    // Get the currently selected emoji and press Enter
+    const selectedAfterMove = page.locator(
+      'button[data-emoji].bg-\\[var\\(--emoji-hover-color\\)\\]'
+    );
+    await expect(selectedAfterMove).toBeVisible();
+    const expectedEmoji = await selectedAfterMove.getAttribute('data-emoji');
+
+    await page.keyboard.press('Enter');
+
+    // The hero should now show the selected emoji (no longer the default)
+    await expect(heroEmoji).toHaveText(expectedEmoji!);
+  });
+
+  test('ArrowDown moves to the next row', async ({ page }) => {
+    await page.goto('/');
+
+    await page.locator('button[data-emoji]').first().waitFor();
+
+    // Initialize keyboard selection
+    await page.keyboard.press('ArrowDown');
+
+    // Move down one more row
+    await page.keyboard.press('ArrowDown');
+
+    // An emoji in the second row should be selected
+    const selectedEmoji = page.locator(
+      'button[data-emoji].bg-\\[var\\(--emoji-hover-color\\)\\]'
+    );
+    await expect(selectedEmoji).toBeVisible();
+
+    // Press Enter and verify selection
+    const expectedEmoji = await selectedEmoji.getAttribute('data-emoji');
+    await page.keyboard.press('Enter');
+
+    const heroEmoji = page.locator('.text-6xl');
+    await expect(heroEmoji).toHaveText(expectedEmoji!);
+  });
+});
+
+test.describe('Scrolling between categories', () => {
+  test('category headers are visible', async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for category headers to render
+    const headers = page.locator('[data-type="header"]');
+    await headers.first().waitFor();
+
+    // The first visible header should be a category name
+    const firstHeaderText = await headers.first().textContent();
+    expect(firstHeaderText).toBeTruthy();
+  });
+
+  test('scrolling reveals different category headers', async ({ page }) => {
+    await page.goto('/');
+
+    await page.locator('[data-type="header"]').first().waitFor();
+
+    // Collect all visible header texts before scrolling
+    const getVisibleHeaders = () =>
+      page
+        .locator('[data-type="header"] [data-testid="emoji-picker-list-header"]')
+        .allTextContents();
+
+    const initialHeaders = await getVisibleHeaders();
+
+    // Use keyboard navigation to scroll far down — ArrowDown triggers scrollToIndex
+    for (let i = 0; i < 60; i++) {
+      await page.keyboard.press('ArrowDown');
+    }
+    await page.waitForTimeout(200);
+
+    // After navigating down, different category headers should be visible
+    const newHeaders = await getVisibleHeaders();
+
+    // At least one header should be different from the initial set
+    const hasNewCategory = newHeaders.some(
+      (header) => !initialHeaders.includes(header)
+    );
+    expect(hasNewCategory).toBe(true);
+  });
+});
+
+test.describe('Search flow', () => {
+  test('typing in search input filters emojis and selecting a result works', async ({ page }) => {
+    await page.goto('/');
+
+    await page.locator('button[data-emoji]').first().waitFor();
+
+    // Focus the search input and type
+    const searchInput = page.locator('input[placeholder="Search emoji"]');
+    await searchInput.fill('thumbs up');
+
+    // Wait for filtered results
+    await page.waitForTimeout(300);
+
+    // Should have emoji results visible
+    const filteredEmojis = page.locator('button[data-emoji]');
+    const count = await filteredEmojis.count();
+    expect(count).toBeGreaterThan(0);
+
+    // Click the first filtered result
+    const firstResult = filteredEmojis.first();
+    const emojiValue = await firstResult.getAttribute('data-emoji');
+    await firstResult.click();
+
+    // Hero should update
+    const heroEmoji = page.locator('.text-6xl');
+    await expect(heroEmoji).toHaveText(emojiValue!);
+  });
+
+  test('pressing Escape clears search and returns full list', async ({ page }) => {
+    await page.goto('/');
+
+    await page.locator('button[data-emoji]').first().waitFor();
+
+    // Get initial emoji count
+    const initialCount = await page.locator('button[data-emoji]').count();
+
+    // Type to search
+    const searchInput = page.locator('input[placeholder="Search emoji"]');
+    await searchInput.fill('thumbs');
+    await page.waitForTimeout(300);
+
+    // Should have fewer results
+    const filteredCount = await page.locator('button[data-emoji]').count();
+    expect(filteredCount).toBeLessThan(initialCount);
+
+    // Press Escape to clear
+    await searchInput.press('Escape');
+
+    // Input should be cleared
+    await expect(searchInput).toHaveValue('');
+
+    // Full list should return
+    await page.waitForTimeout(300);
+    const restoredCount = await page.locator('button[data-emoji]').count();
+    expect(restoredCount).toBeGreaterThanOrEqual(initialCount);
+  });
+});
+
+test.describe('Skin tone selection', () => {
+  test('selecting a skin tone persists on emoji hover in preview', async ({ page }) => {
+    await page.goto('/');
+
+    // Switch to Slack variant which has skin tone and preview
+    const slackTab = page.locator('button', { hasText: 'Slack' });
+    await slackTab.click();
+    await page.locator('button[data-emoji]').first().waitFor();
+
+    // Find and click the skin tone button (shows ✋ by default)
+    const skinToneButton = page.locator('button').filter({ hasText: '✋' }).last();
+    await skinToneButton.click();
+
+    // The skin tone picker should open showing 6 skin tone options
+    // Select a dark skin tone (✋🏿)
+    const darkTone = page.locator('button').filter({ hasText: '✋🏿' });
+    await darkTone.click();
+
+    // Now the skin tone button should show the dark skin tone
+    const updatedSkinTone = page.locator('button').filter({ hasText: '✋🏿' });
+    await expect(updatedSkinTone).toBeVisible();
+  });
+});

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from '@playwright/test';
+
+const PORT = 5174;
+
+export default defineConfig({
+  testDir: '.',
+  timeout: 30_000,
+  retries: 0,
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    headless: true,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+  webServer: {
+    command: `bun run --cwd demo vite --port ${PORT}`,
+    cwd: '..',
+    url: `http://localhost:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
     "release:patch": "bun run --cwd packages/emoji-picker release:patch",
     "release:minor": "bun run --cwd packages/emoji-picker release:minor",
     "release:major": "bun run --cwd packages/emoji-picker release:major",
-    "test:e2e": "bunx playwright test --config e2e/playwright.config.ts",
-    "server:dev": "bun run --cwd packages/server dev",
-    "server:start": "bun run --cwd packages/server start"
+    "test:e2e": "bunx playwright test --config e2e/playwright.config.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,12 @@
     "test:coverage": "bun --cwd packages/emoji-picker test --coverage",
     "release:patch": "bun run --cwd packages/emoji-picker release:patch",
     "release:minor": "bun run --cwd packages/emoji-picker release:minor",
-    "release:major": "bun run --cwd packages/emoji-picker release:major"
+    "release:major": "bun run --cwd packages/emoji-picker release:major",
+    "test:e2e": "bunx playwright test --config e2e/playwright.config.ts",
+    "server:dev": "bun run --cwd packages/server dev",
+    "server:start": "bun run --cwd packages/server start"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1"
   }
 }

--- a/packages/emoji-picker/src/EmojiPicker/__tests__/EmojiPicker.test.tsx
+++ b/packages/emoji-picker/src/EmojiPicker/__tests__/EmojiPicker.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { describe, expect, test, mock } from 'bun:test';
+import { render } from '@testing-library/react';
+
+// Mock the virtualizer
+mock.module('@tanstack/react-virtual', () => ({
+  useVirtualizer: () => ({
+    getVirtualItems: () => [],
+    getTotalSize: () => 0,
+    scrollToIndex: () => {},
+  }),
+  defaultRangeExtractor: (range: any) => range,
+}));
+
+mock.module('unicode-emoji-json/data-by-group.json', () => ({
+  'Smileys & Emotion': {
+    name: 'Smileys & Emotion',
+    slug: 'smileys-emotion',
+    emojis: [],
+  },
+}));
+
+import { EmojiPicker } from '../EmojiPicker';
+
+describe('EmojiPicker', () => {
+  test('renders children inside provider wrapper', () => {
+    const { container } = render(
+      <EmojiPicker>
+        <span data-testid="child">Hello</span>
+      </EmojiPicker>
+    );
+
+    const child = container.querySelector('[data-testid="child"]');
+    expect(child).toBeDefined();
+    expect(child?.textContent).toBe('Hello');
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(
+      <EmojiPicker className="my-custom-class">
+        <div>Content</div>
+      </EmojiPicker>
+    );
+
+    const wrapper = container.firstElementChild;
+    expect(wrapper?.className).toInclude('my-custom-class');
+  });
+
+  test('has tabIndex={0} for focus support', () => {
+    const { container } = render(
+      <EmojiPicker>
+        <div>Content</div>
+      </EmojiPicker>
+    );
+
+    const wrapper = container.firstElementChild;
+    expect(wrapper?.getAttribute('tabindex')).toBe('0');
+  });
+
+  test('uses default values when no props provided', () => {
+    const { container } = render(
+      <EmojiPicker>
+        <div>Content</div>
+      </EmojiPicker>
+    );
+
+    // Should render without errors
+    expect(container.firstElementChild).toBeDefined();
+  });
+
+  test('compound component static properties exist', () => {
+    expect(EmojiPicker.Header).toBeDefined();
+    expect(EmojiPicker.Input).toBeDefined();
+    expect(EmojiPicker.List).toBeDefined();
+    expect(EmojiPicker.Preview).toBeDefined();
+    expect(EmojiPicker.SkinTone).toBeDefined();
+    expect(EmojiPicker.Content).toBeDefined();
+    expect(EmojiPicker.Group).toBeDefined();
+  });
+
+  test('renders with default flex-col layout classes', () => {
+    const { container } = render(
+      <EmojiPicker>
+        <div>Content</div>
+      </EmojiPicker>
+    );
+
+    const wrapper = container.firstElementChild;
+    expect(wrapper?.className).toInclude('flex');
+    expect(wrapper?.className).toInclude('flex-col');
+  });
+});

--- a/packages/emoji-picker/src/EmojiPicker/__tests__/EmojiPickerInput.test.tsx
+++ b/packages/emoji-picker/src/EmojiPicker/__tests__/EmojiPickerInput.test.tsx
@@ -52,9 +52,7 @@ describe('EmojiPickerInput', () => {
   });
 
   test('renders with custom placeholder', () => {
-    const { container } = renderWithProviders(
-      <EmojiPickerInput placeholder="Find an emoji..." />
-    );
+    const { container } = renderWithProviders(<EmojiPickerInput placeholder="Find an emoji..." />);
     const input = container.querySelector('input');
     expect(input?.getAttribute('placeholder')).toBe('Find an emoji...');
   });
@@ -87,9 +85,7 @@ describe('EmojiPickerInput', () => {
     const onClear = mock(() => {});
     store.set(testSearchAtom, 'hello');
 
-    const { container } = renderWithProviders(
-      <EmojiPickerInput onClear={onClear} />
-    );
+    const { container } = renderWithProviders(<EmojiPickerInput onClear={onClear} />);
 
     const clearButton = container.querySelector('button')!;
     fireEvent.click(clearButton);
@@ -124,9 +120,7 @@ describe('EmojiPickerInput', () => {
   });
 
   test('autoFocus prop is forwarded', () => {
-    const { container } = renderWithProviders(
-      <EmojiPickerInput autoFocus />
-    );
+    const { container } = renderWithProviders(<EmojiPickerInput autoFocus />);
     const input = container.querySelector('input');
     // In happy-dom, the focused element should be the input when autoFocus is set
     expect(input).toBeDefined();

--- a/packages/emoji-picker/src/EmojiPicker/__tests__/EmojiPickerInput.test.tsx
+++ b/packages/emoji-picker/src/EmojiPicker/__tests__/EmojiPickerInput.test.tsx
@@ -1,0 +1,155 @@
+import React, { createRef } from 'react';
+import { atom, createStore, Provider } from 'jotai';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { render, fireEvent } from '@testing-library/react';
+import { EmojiPickerProvider } from '../EmojiPickerContext';
+
+// Create writable test atoms
+const testSearchAtom = atom('');
+const testSkinToneAtom = atom('default');
+
+mock.module('unicode-emoji-json/data-by-group.json', () => ({
+  'Smileys & Emotion': {
+    name: 'Smileys & Emotion',
+    slug: 'smileys-emotion',
+    emojis: [],
+  },
+}));
+
+mock.module('../../atoms/emoji', () => ({
+  searchAtom: testSearchAtom,
+  skinToneAtom: testSkinToneAtom,
+  skinToneOnlyAtom: atom((get) => get(testSkinToneAtom)),
+  filteredEmojisAtom: atom([]),
+  hoveredEmojiAtom: atom(null),
+  selectedEmojiAtom: atom(null),
+  selectedPositionAtom: atom(null),
+}));
+
+import { EmojiPickerInput } from '../EmojiPickerInput';
+
+describe('EmojiPickerInput', () => {
+  const store = createStore();
+
+  const renderWithProviders = (ui: React.ReactNode) => {
+    return render(
+      <Provider store={store}>
+        <EmojiPickerProvider emojisPerRow={8} emojiSize={32} maxUnicodeVersion={16.0}>
+          {ui}
+        </EmojiPickerProvider>
+      </Provider>
+    );
+  };
+
+  beforeEach(() => {
+    store.set(testSearchAtom, '');
+  });
+
+  test('renders with default placeholder "Search emoji"', () => {
+    const { container } = renderWithProviders(<EmojiPickerInput />);
+    const input = container.querySelector('input');
+    expect(input?.getAttribute('placeholder')).toBe('Search emoji');
+  });
+
+  test('renders with custom placeholder', () => {
+    const { container } = renderWithProviders(
+      <EmojiPickerInput placeholder="Find an emoji..." />
+    );
+    const input = container.querySelector('input');
+    expect(input?.getAttribute('placeholder')).toBe('Find an emoji...');
+  });
+
+  test('updates searchAtom on typing', () => {
+    const { container } = renderWithProviders(<EmojiPickerInput />);
+    const input = container.querySelector('input')!;
+
+    fireEvent.change(input, { target: { value: 'smile' } });
+    expect(store.get(testSearchAtom)).toBe('smile');
+  });
+
+  test('shows clear button when text is present', () => {
+    store.set(testSearchAtom, 'hello');
+    const { container } = renderWithProviders(<EmojiPickerInput />);
+
+    const buttons = container.querySelectorAll('button');
+    expect(buttons.length).toBe(1);
+  });
+
+  test('hides clear button when input is empty', () => {
+    store.set(testSearchAtom, '');
+    const { container } = renderWithProviders(<EmojiPickerInput />);
+
+    const buttons = container.querySelectorAll('button');
+    expect(buttons.length).toBe(0);
+  });
+
+  test('clear button resets search and calls onClear', () => {
+    const onClear = mock(() => {});
+    store.set(testSearchAtom, 'hello');
+
+    const { container } = renderWithProviders(
+      <EmojiPickerInput onClear={onClear} />
+    );
+
+    const clearButton = container.querySelector('button')!;
+    fireEvent.click(clearButton);
+
+    expect(store.get(testSearchAtom)).toBe('');
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  test('Escape key clears input', () => {
+    store.set(testSearchAtom, 'test');
+    const { container } = renderWithProviders(<EmojiPickerInput />);
+    const input = container.querySelector('input')!;
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(store.get(testSearchAtom)).toBe('');
+  });
+
+  test('hideIcon prop hides search icon', () => {
+    const { container } = renderWithProviders(<EmojiPickerInput hideIcon />);
+
+    // With hideIcon, the search icon div should not be present
+    const iconDiv = container.querySelector('.pointer-events-none');
+    expect(iconDiv).toBeNull();
+  });
+
+  test('search icon is visible by default', () => {
+    const { container } = renderWithProviders(<EmojiPickerInput />);
+
+    const iconDiv = container.querySelector('.pointer-events-none');
+    expect(iconDiv).toBeDefined();
+    expect(iconDiv).not.toBeNull();
+  });
+
+  test('autoFocus prop is forwarded', () => {
+    const { container } = renderWithProviders(
+      <EmojiPickerInput autoFocus />
+    );
+    const input = container.querySelector('input');
+    // In happy-dom, the focused element should be the input when autoFocus is set
+    expect(input).toBeDefined();
+    expect(input).not.toBeNull();
+  });
+
+  test('supports custom endIcon', () => {
+    store.set(testSearchAtom, 'text');
+    const { container } = renderWithProviders(
+      <EmojiPickerInput endIcon={<span data-testid="custom-icon">X</span>} />
+    );
+
+    const customIcon = container.querySelector('[data-testid="custom-icon"]');
+    expect(customIcon).toBeDefined();
+    expect(customIcon).not.toBeNull();
+  });
+
+  test('forwards ref to input element', () => {
+    const ref = createRef<HTMLInputElement>();
+    renderWithProviders(<EmojiPickerInput ref={ref} />);
+
+    expect(ref.current).toBeDefined();
+    expect(ref.current).not.toBeNull();
+    expect(ref.current?.tagName).toBe('INPUT');
+  });
+});

--- a/packages/emoji-picker/src/EmojiPicker/__tests__/EmojiPickerPreview.test.tsx
+++ b/packages/emoji-picker/src/EmojiPicker/__tests__/EmojiPickerPreview.test.tsx
@@ -52,9 +52,7 @@ describe('EmojiPickerPreview', () => {
       <span>{previewedEmoji ? previewedEmoji.emoji : 'none'}</span>
     ));
 
-    const { container } = renderWithProviders(
-      <EmojiPickerPreview>{childFn}</EmojiPickerPreview>
-    );
+    const { container } = renderWithProviders(<EmojiPickerPreview>{childFn}</EmojiPickerPreview>);
 
     expect(childFn).toHaveBeenCalled();
     expect(container.textContent).toInclude('none');
@@ -71,9 +69,7 @@ describe('EmojiPickerPreview', () => {
 
     const { container } = renderWithProviders(
       <EmojiPickerPreview>
-        {({ previewedEmoji }) => (
-          <span>{previewedEmoji ? previewedEmoji.emoji : 'none'}</span>
-        )}
+        {({ previewedEmoji }) => <span>{previewedEmoji ? previewedEmoji.emoji : 'none'}</span>}
       </EmojiPickerPreview>
     );
 
@@ -117,9 +113,7 @@ describe('EmojiPickerPreview', () => {
   test('container height based on emoji size (minimum 44px)', () => {
     // With emojiSize=32, containerHeight = Math.max(32 * 1.1, 44) = 44
     const { container } = renderWithProviders(
-      <EmojiPickerPreview>
-        {() => <span>Preview</span>}
-      </EmojiPickerPreview>,
+      <EmojiPickerPreview>{() => <span>Preview</span>}</EmojiPickerPreview>,
       32
     );
 
@@ -130,9 +124,7 @@ describe('EmojiPickerPreview', () => {
   test('container height scales with large emoji size', () => {
     // With emojiSize=60, containerHeight = Math.max(60 * 1.1, 44) = 66
     const { container } = renderWithProviders(
-      <EmojiPickerPreview>
-        {() => <span>Preview</span>}
-      </EmojiPickerPreview>,
+      <EmojiPickerPreview>{() => <span>Preview</span>}</EmojiPickerPreview>,
       60
     );
 

--- a/packages/emoji-picker/src/EmojiPicker/__tests__/EmojiPickerPreview.test.tsx
+++ b/packages/emoji-picker/src/EmojiPicker/__tests__/EmojiPickerPreview.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { atom, createStore, Provider } from 'jotai';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { render } from '@testing-library/react';
+import { EmojiPickerProvider } from '../EmojiPickerContext';
+
+import type { EmojiMetadata } from '../../types/emoji';
+
+const testHoveredEmojiAtom = atom<EmojiMetadata | null>(null);
+const testSkinToneAtom = atom<string>('default');
+
+mock.module('unicode-emoji-json/data-by-group.json', () => ({
+  'Smileys & Emotion': {
+    name: 'Smileys & Emotion',
+    slug: 'smileys-emotion',
+    emojis: [],
+  },
+}));
+
+mock.module('../../atoms/emoji', () => ({
+  hoveredEmojiAtom: testHoveredEmojiAtom,
+  skinToneAtom: testSkinToneAtom,
+  skinToneOnlyAtom: atom((get) => get(testSkinToneAtom)),
+  searchAtom: atom(''),
+  filteredEmojisAtom: atom([]),
+  selectedEmojiAtom: atom(null),
+  selectedPositionAtom: atom(null),
+}));
+
+import { EmojiPickerPreview } from '../EmojiPickerPreview';
+
+describe('EmojiPickerPreview', () => {
+  const store = createStore();
+
+  const renderWithProviders = (ui: React.ReactNode, emojiSize = 32) => {
+    return render(
+      <Provider store={store}>
+        <EmojiPickerProvider emojisPerRow={8} emojiSize={emojiSize} maxUnicodeVersion={16.0}>
+          {ui}
+        </EmojiPickerProvider>
+      </Provider>
+    );
+  };
+
+  beforeEach(() => {
+    store.set(testHoveredEmojiAtom, null);
+    store.set(testSkinToneAtom, 'default');
+  });
+
+  test('calls render prop children with null when no emoji hovered', () => {
+    const childFn = mock(({ previewedEmoji }: { previewedEmoji: EmojiMetadata | null }) => (
+      <span>{previewedEmoji ? previewedEmoji.emoji : 'none'}</span>
+    ));
+
+    const { container } = renderWithProviders(
+      <EmojiPickerPreview>{childFn}</EmojiPickerPreview>
+    );
+
+    expect(childFn).toHaveBeenCalled();
+    expect(container.textContent).toInclude('none');
+  });
+
+  test('calls render prop children with emoji metadata when hovered', () => {
+    const emoji: EmojiMetadata = {
+      emoji: '😀',
+      name: 'grinning face',
+      slug: 'grinning-face',
+      skin_tone_support: false,
+    };
+    store.set(testHoveredEmojiAtom, emoji);
+
+    const { container } = renderWithProviders(
+      <EmojiPickerPreview>
+        {({ previewedEmoji }) => (
+          <span>{previewedEmoji ? previewedEmoji.emoji : 'none'}</span>
+        )}
+      </EmojiPickerPreview>
+    );
+
+    expect(container.textContent).toInclude('😀');
+  });
+
+  test('applies skin tone to previewed emoji', () => {
+    const emoji: EmojiMetadata = {
+      emoji: '✋',
+      name: 'raised hand',
+      slug: 'raised-hand',
+      skin_tone_support: true,
+    };
+    store.set(testHoveredEmojiAtom, emoji);
+    store.set(testSkinToneAtom, 'dark');
+
+    const { container } = renderWithProviders(
+      <EmojiPickerPreview>
+        {({ previewedEmoji }) => (
+          <span data-testid="preview">{previewedEmoji ? previewedEmoji.emoji : 'none'}</span>
+        )}
+      </EmojiPickerPreview>
+    );
+
+    const preview = container.querySelector('[data-testid="preview"]');
+    // With dark skin tone applied, the emoji should contain the dark skin tone modifier
+    expect(preview?.textContent).toInclude('✋🏿');
+  });
+
+  test('applies custom className', () => {
+    const { container } = renderWithProviders(
+      <EmojiPickerPreview className="my-custom-class">
+        {() => <span>Preview</span>}
+      </EmojiPickerPreview>
+    );
+
+    const outerDiv = container.firstElementChild;
+    expect(outerDiv?.className).toInclude('my-custom-class');
+  });
+
+  test('container height based on emoji size (minimum 44px)', () => {
+    // With emojiSize=32, containerHeight = Math.max(32 * 1.1, 44) = 44
+    const { container } = renderWithProviders(
+      <EmojiPickerPreview>
+        {() => <span>Preview</span>}
+      </EmojiPickerPreview>,
+      32
+    );
+
+    const innerDiv = container.querySelector('[style]');
+    expect(innerDiv?.getAttribute('style')).toInclude('height: 44px');
+  });
+
+  test('container height scales with large emoji size', () => {
+    // With emojiSize=60, containerHeight = Math.max(60 * 1.1, 44) = 66
+    const { container } = renderWithProviders(
+      <EmojiPickerPreview>
+        {() => <span>Preview</span>}
+      </EmojiPickerPreview>,
+      60
+    );
+
+    const innerDiv = container.querySelector('[style]');
+    expect(innerDiv?.getAttribute('style')).toInclude('height: 66px');
+  });
+});

--- a/packages/emoji-picker/src/EmojiPicker/__tests__/EmojiPickerSkinTone.test.tsx
+++ b/packages/emoji-picker/src/EmojiPicker/__tests__/EmojiPickerSkinTone.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { atom, createStore, Provider } from 'jotai';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { render, fireEvent } from '@testing-library/react';
+import { EmojiPickerProvider } from '../EmojiPickerContext';
+
+const testSkinToneAtom = atom<string>('default');
+
+mock.module('unicode-emoji-json/data-by-group.json', () => ({
+  'Smileys & Emotion': {
+    name: 'Smileys & Emotion',
+    slug: 'smileys-emotion',
+    emojis: [],
+  },
+}));
+
+mock.module('../../atoms/emoji', () => ({
+  skinToneAtom: testSkinToneAtom,
+  skinToneOnlyAtom: atom((get) => get(testSkinToneAtom)),
+  searchAtom: atom(''),
+  filteredEmojisAtom: atom([]),
+  hoveredEmojiAtom: atom(null),
+  selectedEmojiAtom: atom(null),
+  selectedPositionAtom: atom(null),
+}));
+
+import { EmojiPickerSkinTone } from '../EmojiPickerSkinTone';
+
+describe('EmojiPickerSkinTone', () => {
+  const store = createStore();
+
+  const renderWithProviders = (ui: React.ReactNode) => {
+    return render(
+      <Provider store={store}>
+        <EmojiPickerProvider emojisPerRow={8} emojiSize={32} maxUnicodeVersion={16.0}>
+          {ui}
+        </EmojiPickerProvider>
+      </Provider>
+    );
+  };
+
+  beforeEach(() => {
+    store.set(testSkinToneAtom, 'default');
+  });
+
+  test('renders current skin tone emoji button', () => {
+    const { container } = renderWithProviders(<EmojiPickerSkinTone />);
+    const button = container.querySelector('button');
+    expect(button).toBeDefined();
+    expect(button?.textContent).toInclude('✋');
+  });
+
+  test('defaults to ✋ when no tone is set', () => {
+    store.set(testSkinToneAtom, 'default');
+    const { container } = renderWithProviders(<EmojiPickerSkinTone />);
+    const button = container.querySelector('button');
+    expect(button?.textContent).toInclude('✋');
+  });
+
+  test('opens picker on click showing all 6 skin tones', () => {
+    const { container } = renderWithProviders(<EmojiPickerSkinTone />);
+
+    // Click to open
+    const button = container.querySelector('button')!;
+    fireEvent.click(button);
+
+    // Should now show 6 skin tone buttons
+    const buttons = container.querySelectorAll('button');
+    expect(buttons.length).toBe(6);
+  });
+
+  test('shows "Choose your default skin tone" text when open', () => {
+    const { container } = renderWithProviders(<EmojiPickerSkinTone />);
+
+    const button = container.querySelector('button')!;
+    fireEvent.click(button);
+
+    expect(container.textContent).toInclude('Choose your default skin tone');
+  });
+
+  test('selecting a tone updates skinToneAtom and closes picker', () => {
+    const { container } = renderWithProviders(<EmojiPickerSkinTone />);
+
+    // Open picker
+    const button = container.querySelector('button')!;
+    fireEvent.click(button);
+
+    // Select "dark" tone (last button)
+    const buttons = container.querySelectorAll('button');
+    const darkButton = buttons[5]; // last = dark
+    fireEvent.click(darkButton);
+
+    // Atom should be updated
+    expect(store.get(testSkinToneAtom)).toBe('dark');
+
+    // Picker should be closed (only 1 button visible again)
+    const buttonsAfter = container.querySelectorAll('button');
+    expect(buttonsAfter.length).toBe(1);
+  });
+
+  test('displays correct emoji for selected skin tone', () => {
+    store.set(testSkinToneAtom, 'light');
+    const { container } = renderWithProviders(<EmojiPickerSkinTone />);
+    const button = container.querySelector('button');
+    expect(button?.textContent).toInclude('✋🏻');
+  });
+});

--- a/packages/emoji-picker/src/hooks/__tests__/useEmojiKeyboardNavigation.test.ts
+++ b/packages/emoji-picker/src/hooks/__tests__/useEmojiKeyboardNavigation.test.ts
@@ -31,10 +31,30 @@ mock.module('../../atoms/emoji', () => ({
 
 import { useEmojiKeyboardNavigation } from '../useEmojiKeyboardNavigation';
 
-const emoji1: EmojiMetadata = { emoji: '😀', name: 'grinning face', slug: 'grinning-face', skin_tone_support: false };
-const emoji2: EmojiMetadata = { emoji: '😃', name: 'grinning face with big eyes', slug: 'grinning-face-with-big-eyes', skin_tone_support: false };
-const emoji3: EmojiMetadata = { emoji: '✋', name: 'raised hand', slug: 'raised-hand', skin_tone_support: true };
-const emoji4: EmojiMetadata = { emoji: '👋', name: 'waving hand', slug: 'waving-hand', skin_tone_support: true };
+const emoji1: EmojiMetadata = {
+  emoji: '😀',
+  name: 'grinning face',
+  slug: 'grinning-face',
+  skin_tone_support: false,
+};
+const emoji2: EmojiMetadata = {
+  emoji: '😃',
+  name: 'grinning face with big eyes',
+  slug: 'grinning-face-with-big-eyes',
+  skin_tone_support: false,
+};
+const emoji3: EmojiMetadata = {
+  emoji: '✋',
+  name: 'raised hand',
+  slug: 'raised-hand',
+  skin_tone_support: true,
+};
+const emoji4: EmojiMetadata = {
+  emoji: '👋',
+  name: 'waving hand',
+  slug: 'waving-hand',
+  skin_tone_support: true,
+};
 
 type Row = { type: 'header'; content: string } | { type: 'emojis'; content: EmojiMetadata[] };
 

--- a/packages/emoji-picker/src/hooks/__tests__/useEmojiKeyboardNavigation.test.ts
+++ b/packages/emoji-picker/src/hooks/__tests__/useEmojiKeyboardNavigation.test.ts
@@ -4,6 +4,7 @@ import { renderHook, act } from '@testing-library/react';
 import React, { useCallback, useRef } from 'react';
 
 import type { EmojiMetadata } from '../../types/emoji';
+import { EmojiPickerProvider } from '../../EmojiPicker/EmojiPickerContext';
 
 // Create writable test atoms
 const testSearchAtom = atom('');
@@ -79,7 +80,6 @@ describe('useEmojiKeyboardNavigation', () => {
 
   // Create a stable wrapper component that memoizes the context value
   const StableWrapper = ({ children }: { children: React.ReactNode }) => {
-    const { EmojiPickerProvider } = require('../../EmojiPicker/EmojiPickerContext');
     // Use a ref-based onEmojiSelect to keep it stable
     const onEmojiSelectRef = useRef(stableOnEmojiSelect);
     const stableCallback = useCallback((emoji: string) => {

--- a/packages/emoji-picker/src/hooks/__tests__/useEmojiKeyboardNavigation.test.ts
+++ b/packages/emoji-picker/src/hooks/__tests__/useEmojiKeyboardNavigation.test.ts
@@ -1,0 +1,267 @@
+import { atom, createStore, Provider } from 'jotai';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { renderHook, act } from '@testing-library/react';
+import React, { useCallback, useRef } from 'react';
+
+import type { EmojiMetadata } from '../../types/emoji';
+
+// Create writable test atoms
+const testSearchAtom = atom('');
+const testSelectedPositionAtom = atom<{ row: number; column: number } | null>(null);
+const testHoveredEmojiAtom = atom<EmojiMetadata | null>(null);
+const testSelectedEmojiAtom = atom<string | null>(null);
+
+mock.module('unicode-emoji-json/data-by-group.json', () => ({
+  'Smileys & Emotion': {
+    name: 'Smileys & Emotion',
+    slug: 'smileys-emotion',
+    emojis: [],
+  },
+}));
+
+mock.module('../../atoms/emoji', () => ({
+  searchAtom: testSearchAtom,
+  selectedPositionAtom: testSelectedPositionAtom,
+  hoveredEmojiAtom: testHoveredEmojiAtom,
+  selectedEmojiAtom: testSelectedEmojiAtom,
+  skinToneAtom: atom('default'),
+  skinToneOnlyAtom: atom('default'),
+  filteredEmojisAtom: atom([]),
+}));
+
+import { useEmojiKeyboardNavigation } from '../useEmojiKeyboardNavigation';
+
+const emoji1: EmojiMetadata = { emoji: '😀', name: 'grinning face', slug: 'grinning-face', skin_tone_support: false };
+const emoji2: EmojiMetadata = { emoji: '😃', name: 'grinning face with big eyes', slug: 'grinning-face-with-big-eyes', skin_tone_support: false };
+const emoji3: EmojiMetadata = { emoji: '✋', name: 'raised hand', slug: 'raised-hand', skin_tone_support: true };
+const emoji4: EmojiMetadata = { emoji: '👋', name: 'waving hand', slug: 'waving-hand', skin_tone_support: true };
+
+type Row = { type: 'header'; content: string } | { type: 'emojis'; content: EmojiMetadata[] };
+
+const mockRows: Row[] = [
+  { type: 'header', content: 'Smileys & Emotion' },
+  { type: 'emojis', content: [emoji1, emoji2] },
+  { type: 'header', content: 'People & Body' },
+  { type: 'emojis', content: [emoji3, emoji4] },
+];
+
+// Stable reference for onEmojiSelect to avoid infinite re-renders
+const onEmojiSelectCalls: string[] = [];
+const stableOnEmojiSelect = (emoji: string) => {
+  onEmojiSelectCalls.push(emoji);
+};
+
+const mockScrollToIndex = mock(() => {});
+const stableVirtualizer = { scrollToIndex: mockScrollToIndex };
+
+describe('useEmojiKeyboardNavigation', () => {
+  const store = createStore();
+
+  // Create a stable wrapper component that memoizes the context value
+  const StableWrapper = ({ children }: { children: React.ReactNode }) => {
+    const { EmojiPickerProvider } = require('../../EmojiPicker/EmojiPickerContext');
+    // Use a ref-based onEmojiSelect to keep it stable
+    const onEmojiSelectRef = useRef(stableOnEmojiSelect);
+    const stableCallback = useCallback((emoji: string) => {
+      onEmojiSelectRef.current(emoji);
+    }, []);
+
+    return React.createElement(
+      Provider,
+      { store },
+      React.createElement(
+        EmojiPickerProvider,
+        {
+          emojisPerRow: 8,
+          emojiSize: 32,
+          maxUnicodeVersion: 16.0,
+          onEmojiSelect: stableCallback,
+        },
+        children
+      )
+    );
+  };
+
+  beforeEach(() => {
+    store.set(testSearchAtom, '');
+    store.set(testSelectedPositionAtom, null);
+    store.set(testHoveredEmojiAtom, null);
+    store.set(testSelectedEmojiAtom, null);
+    onEmojiSelectCalls.length = 0;
+    mockScrollToIndex.mockClear();
+  });
+
+  const renderNavHook = (rows: Row[] = mockRows) => {
+    return renderHook(
+      () =>
+        useEmojiKeyboardNavigation({
+          rows,
+          virtualizer: stableVirtualizer,
+        }),
+      { wrapper: StableWrapper }
+    );
+  };
+
+  test('ArrowDown initializes selection at first emoji row', () => {
+    renderNavHook();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    });
+
+    const pos = store.get(testSelectedPositionAtom);
+    expect(pos).toEqual({ row: 1, column: 0 });
+    expect(store.get(testHoveredEmojiAtom)).toEqual(emoji1);
+  });
+
+  test('ArrowRight initializes selection at first emoji row', () => {
+    renderNavHook();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    });
+
+    const pos = store.get(testSelectedPositionAtom);
+    expect(pos).toEqual({ row: 1, column: 0 });
+  });
+
+  test('ArrowDown navigates between emoji rows, skipping headers', () => {
+    store.set(testSelectedPositionAtom, { row: 1, column: 0 });
+    renderNavHook();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    });
+
+    const pos = store.get(testSelectedPositionAtom);
+    expect(pos).toEqual({ row: 3, column: 0 });
+    expect(store.get(testHoveredEmojiAtom)).toEqual(emoji3);
+  });
+
+  test('ArrowUp navigates between emoji rows, skipping headers', () => {
+    store.set(testSelectedPositionAtom, { row: 3, column: 0 });
+    renderNavHook();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+    });
+
+    const pos = store.get(testSelectedPositionAtom);
+    expect(pos).toEqual({ row: 1, column: 0 });
+    expect(store.get(testHoveredEmojiAtom)).toEqual(emoji1);
+  });
+
+  test('ArrowRight navigates within a row', () => {
+    store.set(testSelectedPositionAtom, { row: 1, column: 0 });
+    renderNavHook();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    });
+
+    const pos = store.get(testSelectedPositionAtom);
+    expect(pos).toEqual({ row: 1, column: 1 });
+    expect(store.get(testHoveredEmojiAtom)).toEqual(emoji2);
+  });
+
+  test('ArrowLeft navigates within a row', () => {
+    store.set(testSelectedPositionAtom, { row: 1, column: 1 });
+    renderNavHook();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    });
+
+    const pos = store.get(testSelectedPositionAtom);
+    expect(pos).toEqual({ row: 1, column: 0 });
+    expect(store.get(testHoveredEmojiAtom)).toEqual(emoji1);
+  });
+
+  test('ArrowLeft at start of row wraps to end of previous row', () => {
+    store.set(testSelectedPositionAtom, { row: 3, column: 0 });
+    renderNavHook();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    });
+
+    const pos = store.get(testSelectedPositionAtom);
+    expect(pos).toEqual({ row: 1, column: 1 });
+    expect(store.get(testHoveredEmojiAtom)).toEqual(emoji2);
+  });
+
+  test('ArrowRight at end of row wraps to start of next row', () => {
+    store.set(testSelectedPositionAtom, { row: 1, column: 1 });
+    renderNavHook();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    });
+
+    const pos = store.get(testSelectedPositionAtom);
+    expect(pos).toEqual({ row: 3, column: 0 });
+    expect(store.get(testHoveredEmojiAtom)).toEqual(emoji3);
+  });
+
+  test('column position is clamped when moving up/down to shorter row', () => {
+    const rows: Row[] = [
+      { type: 'emojis', content: [emoji1, emoji2, emoji3] },
+      { type: 'emojis', content: [emoji4] },
+    ];
+
+    store.set(testSelectedPositionAtom, { row: 0, column: 2 });
+    renderNavHook(rows);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    });
+
+    const pos = store.get(testSelectedPositionAtom);
+    expect(pos).toEqual({ row: 1, column: 0 });
+  });
+
+  test('Enter triggers onEmojiSelect with current emoji', () => {
+    store.set(testSelectedPositionAtom, { row: 1, column: 0 });
+    renderNavHook();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+
+    expect(onEmojiSelectCalls).toContain('😀');
+    expect(store.get(testSelectedEmojiAtom)).toBe('😀');
+  });
+
+  test('Space triggers onEmojiSelect with current emoji', () => {
+    store.set(testSelectedPositionAtom, { row: 1, column: 1 });
+    renderNavHook();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    });
+
+    expect(onEmojiSelectCalls).toContain('😃');
+    expect(store.get(testSelectedEmojiAtom)).toBe('😃');
+  });
+
+  test('scrollToIndex called on navigation', () => {
+    renderNavHook();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    });
+
+    expect(mockScrollToIndex).toHaveBeenCalled();
+  });
+
+  test('search change auto-selects first emoji', () => {
+    renderNavHook();
+
+    act(() => {
+      store.set(testSearchAtom, 'grin');
+    });
+
+    const pos = store.get(testSelectedPositionAtom);
+    expect(pos).toEqual({ row: 1, column: 0 });
+  });
+});

--- a/packages/emoji-picker/src/hooks/__tests__/useVirtualizedList.test.ts
+++ b/packages/emoji-picker/src/hooks/__tests__/useVirtualizedList.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { renderHook } from '@testing-library/react';
+
+// Mock virtualizer
+const mockVirtualizer = {
+  getVirtualItems: () => [],
+  getTotalSize: () => 0,
+  scrollToIndex: () => {},
+};
+
+mock.module('@tanstack/react-virtual', () => ({
+  useVirtualizer: () => mockVirtualizer,
+  defaultRangeExtractor: (range: any) => {
+    const start = range.startIndex;
+    const end = range.endIndex;
+    const result = [];
+    for (let i = start; i <= end; i++) {
+      result.push(i);
+    }
+    return result;
+  },
+}));
+
+import { useVirtualizedList } from '../useVirtualizedList';
+
+type TestRow = { type: 'header'; content: string } | { type: 'emojis'; content: string[] };
+
+const testRows: TestRow[] = [
+  { type: 'header', content: 'Category A' },
+  { type: 'emojis', content: ['😀', '😃'] },
+  { type: 'header', content: 'Category B' },
+  { type: 'emojis', content: ['✋', '👋'] },
+];
+
+describe('useVirtualizedList', () => {
+  const defaultOptions = {
+    rows: testRows,
+    getScrollElement: () => null,
+    estimateSize: () => 32,
+    isHeader: (row: TestRow) => row.type === 'header',
+  };
+
+  test('isSticky returns true for header indexes', () => {
+    const { result } = renderHook(() => useVirtualizedList(defaultOptions));
+
+    expect(result.current.isSticky(0)).toBe(true);
+    expect(result.current.isSticky(2)).toBe(true);
+  });
+
+  test('isSticky returns false for non-header indexes', () => {
+    const { result } = renderHook(() => useVirtualizedList(defaultOptions));
+
+    expect(result.current.isSticky(1)).toBe(false);
+    expect(result.current.isSticky(3)).toBe(false);
+  });
+
+  test('hideStickyHeader disables sticky behavior (empty stickyIndexes)', () => {
+    const { result } = renderHook(() =>
+      useVirtualizedList({ ...defaultOptions, hideStickyHeader: true })
+    );
+
+    // When hideStickyHeader is true, no indexes should be sticky
+    expect(result.current.isSticky(0)).toBe(false);
+    expect(result.current.isSticky(2)).toBe(false);
+  });
+
+  test('isActiveSticky returns false when hideStickyHeader is true', () => {
+    const { result } = renderHook(() =>
+      useVirtualizedList({ ...defaultOptions, hideStickyHeader: true })
+    );
+
+    expect(result.current.isActiveSticky(0)).toBe(false);
+    expect(result.current.isActiveSticky(2)).toBe(false);
+  });
+
+  test('returns a virtualizer object', () => {
+    const { result } = renderHook(() => useVirtualizedList(defaultOptions));
+
+    expect(result.current.virtualizer).toBeDefined();
+    expect(result.current.virtualizer.getVirtualItems).toBeDefined();
+    expect(result.current.virtualizer.getTotalSize).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for core components (`EmojiPicker`, `EmojiPickerInput`, `EmojiPickerPreview`, `EmojiPickerSkinTone`) and hooks (`useEmojiKeyboardNavigation`, `useVirtualizedList`)
- Add Playwright e2e tests covering emoji click selection, keyboard navigation, category scrolling, search flow, and skin tone selection
- Add a new `e2e` CI job that runs Playwright tests on every PR alongside existing lint/test/build checks
- Pin all GitHub Actions to commit SHAs for supply chain security

## Test plan
- [x] Verify the `test` CI job still passes (lint, format, unit tests, build)
- [x] Verify the new `e2e` CI job installs Playwright, builds the library, and runs e2e tests successfully
- [x] Confirm test artifacts are uploaded on failure