### PR TITLE
Improve copy button feedback and surface-aware styling

### DIFF
--- a/demo/src/components/ClipboardButton.tsx
+++ b/demo/src/components/ClipboardButton.tsx
@@ -1,7 +1,29 @@
 
 import { useState } from 'react';
 
-export const ClipboardButton = ({ text }: { text: string }) => {
+type ClipboardButtonVariant = "surface" | "code";
+
+interface ClipboardButtonProps {
+  text: string;
+  /**
+   * "surface" (default): theme-aware chip for normal light/dark surfaces.
+   * "code": glass styling tuned for the always-dark Prism code block.
+   */
+  variant?: ClipboardButtonVariant;
+}
+
+const VARIANT_CLASSES: Record<ClipboardButtonVariant, { idle: string; copied: string }> = {
+  surface: {
+    idle: "bg-zinc-100 dark:bg-zinc-800 hover:bg-zinc-200 dark:hover:bg-zinc-700 text-zinc-600 dark:text-zinc-300 ring-zinc-200 dark:ring-zinc-700",
+    copied: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400 ring-emerald-200 dark:ring-emerald-500/30",
+  },
+  code: {
+    idle: "bg-white/5 text-zinc-400 ring-white/10 hover:bg-white/10 hover:text-zinc-200 backdrop-blur-sm",
+    copied: "bg-emerald-500/15 text-emerald-400 ring-emerald-500/30 backdrop-blur-sm",
+  },
+};
+
+export const ClipboardButton = ({ text, variant = "surface" }: ClipboardButtonProps) => {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
@@ -14,32 +36,50 @@ export const ClipboardButton = ({ text }: { text: string }) => {
     }
   };
 
+  const iconProps = {
+    xmlns: "http://www.w3.org/2000/svg",
+    width: 16,
+    height: 16,
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: 2,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+  };
+
+  const classes = VARIANT_CLASSES[variant];
+
   return (
     <button
       onClick={handleCopy}
-      className={`absolute right-2 top-2 text-xs px-2 py-1 rounded-md
-        ${copied 
-          ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400"
-          : "bg-zinc-100 dark:bg-zinc-800 hover:bg-zinc-200 dark:hover:bg-zinc-700 text-zinc-600 dark:text-zinc-300"
-        } transition-colors`}
+      aria-label={copied ? "Copied" : "Copy to clipboard"}
+      className={`absolute right-2 top-2 text-xs px-2 py-1 rounded-md ring-1 transition-colors
+        ${copied ? classes.copied : classes.idle}`}
     >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="16"
-        height="16"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        className={`lucide lucide-copy h-3 w-3`}
-      >
-        <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
-        <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
-      </svg>
+      {/* Both icons are stacked so they can crossfade/scale into one another */}
+      <span className="relative block h-3 w-3">
+        {/* Copy icon */}
+        <svg
+          {...iconProps}
+          aria-hidden="true"
+          className={`lucide lucide-copy absolute inset-0 h-3 w-3 transition-all duration-200 ease-out
+            ${copied ? "scale-50 opacity-0" : "scale-100 opacity-100"}`}
+        >
+          <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+          <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+        </svg>
 
+        {/* Check icon */}
+        <svg
+          {...iconProps}
+          aria-hidden="true"
+          className={`lucide lucide-check absolute inset-0 h-3 w-3 transition-all duration-200 ease-out
+            ${copied ? "scale-100 opacity-100" : "scale-50 opacity-0"}`}
+        >
+          <path d="M20 6 9 17l-5-5" />
+        </svg>
+      </span>
     </button>
   );
 };
-

--- a/demo/src/components/CodeBlock.tsx
+++ b/demo/src/components/CodeBlock.tsx
@@ -23,7 +23,7 @@ export function CodeBlock({
           <div className="relative">
             {!hideCopyButton && (
               <div className="sticky right-2 top-2 float-right z-10">
-                <ClipboardButton text={code} />
+                <ClipboardButton text={code} variant="code" />
               </div>
             )}
             <pre

--- a/demo/src/components/TailwindSetupTabs.tsx
+++ b/demo/src/components/TailwindSetupTabs.tsx
@@ -58,7 +58,7 @@ export function TailwindSetupTabs() {
         </p>
         <div className="relative">
           <CodeBlock hideCopyButton code={TAILWIND_CONFIGS[activeTab].code} />
-          <ClipboardButton text={TAILWIND_CONFIGS[activeTab].code} />
+          <ClipboardButton text={TAILWIND_CONFIGS[activeTab].code} variant="code" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What

Improves the copy button in the docs/demo site so copying is visually obvious, and fixes the button styling that looked off on different surfaces.

### Icon transform
Previously copying only changed the button's background color. Now the **copy icon crossfades/scales into a checkmark** (lucide `copy` → lucide `check`, same design family — 24×24 viewBox, stroke-based, round caps), so the action reads clearly.

### Surface-aware styling
The button is used on two different surfaces:
- **Normal surfaces** (`PackageManagerTabs` — the Installation tabs) follow the site light/dark theme.
- **The always-dark Prism code block** (`CodeBlock`, and the button overlaid in `TailwindSetupTabs`) is dark regardless of site theme.

A single style couldn't serve both — a light chip clashed on the dark code block, and the glass style was invisible on light backgrounds. So `ClipboardButton` now takes a `variant` prop:

- `"surface"` (default) — theme-aware chip (`zinc-100`/`zinc-800`), the original look.
- `"code"` — subtle glass (`white/5` + faint ring + blur), tuned for the dark code surface.

`CodeBlock` and `TailwindSetupTabs` pass `variant="code"`; `PackageManagerTabs` keeps the default.

Also adds an `aria-label` that flips between "Copy to clipboard" / "Copied".

## Test
- `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)