### PR TITLE
fix: defer emoji support detection out of module evaluation

### DIFF
--- a/packages/emoji-picker/src/EmojiPicker/CustomEmojiCategories.tsx
+++ b/packages/emoji-picker/src/EmojiPicker/CustomEmojiCategories.tsx
@@ -26,8 +26,6 @@ interface CustomEmojiCategoriesProps {
   containerHeight?: number;
 }
 
-const emojiCategories = filterSupportedEmojis(emojiData as EmojiGroup[]);
-
 export function CustomEmojiCategories({
   hideStickyHeader = false,
   containerHeight = 364,
@@ -36,6 +34,10 @@ export function CustomEmojiCategories({
   const skinTone = useAtomValue(skinToneAtom);
 
   const parentRef = useRef<HTMLDivElement>(null);
+
+  // Deferred out of module evaluation: canvas-based support detection is
+  // expensive and must only run when the picker actually renders.
+  const emojiCategories = useMemo(() => filterSupportedEmojis(emojiData as EmojiGroup[]), []);
 
   const rows = useMemo<Row[]>(() => {
     const allRows: Row[] = [];
@@ -110,7 +112,7 @@ export function CustomEmojiCategories({
     });
 
     return allRows;
-  }, [emojisPerRow, skinTone, customSections, frequentlyUsedEmojis]);
+  }, [emojiCategories, emojisPerRow, skinTone, customSections, frequentlyUsedEmojis]);
 
   const { virtualizer, isSticky, isActiveSticky } = useVirtualizedList({
     rows,

--- a/packages/emoji-picker/src/EmojiPicker/CustomEmojiCategories.tsx
+++ b/packages/emoji-picker/src/EmojiPicker/CustomEmojiCategories.tsx
@@ -35,8 +35,6 @@ export function CustomEmojiCategories({
 
   const parentRef = useRef<HTMLDivElement>(null);
 
-  // Deferred out of module evaluation: canvas-based support detection is
-  // expensive and must only run when the picker actually renders.
   const emojiCategories = useMemo(() => filterSupportedEmojis(emojiData as EmojiGroup[]), []);
 
   const rows = useMemo<Row[]>(() => {

--- a/packages/emoji-picker/src/EmojiPicker/EmojiCategories.tsx
+++ b/packages/emoji-picker/src/EmojiPicker/EmojiCategories.tsx
@@ -19,8 +19,6 @@ interface EmojiCategoriesProps {
   containerHeight?: number;
 }
 
-const emojiCategories = filterSupportedEmojis(emojiData as EmojiGroup[]);
-
 function EmojiCategoriesBase(props: EmojiCategoriesProps) {
   const { customSections, frequentlyUsedEmojis } = useEmojiPicker();
 
@@ -43,6 +41,10 @@ function StandardEmojiCategories({
 
   const parentRef = useRef<HTMLDivElement>(null);
 
+  // Deferred out of module evaluation: canvas-based support detection is
+  // expensive and must only run when the picker actually renders.
+  const emojiCategories = useMemo(() => filterSupportedEmojis(emojiData as EmojiGroup[]), []);
+
   const rows = useMemo<Row[]>(() => {
     return emojiCategories.flatMap((category) => {
       const rows: Row[] = [];
@@ -62,7 +64,7 @@ function StandardEmojiCategories({
       }
       return rows;
     });
-  }, [emojisPerRow, skinTone]);
+  }, [emojiCategories, emojisPerRow, skinTone]);
 
   const { virtualizer, isSticky, isActiveSticky } = useVirtualizedList({
     rows,

--- a/packages/emoji-picker/src/EmojiPicker/EmojiCategories.tsx
+++ b/packages/emoji-picker/src/EmojiPicker/EmojiCategories.tsx
@@ -41,8 +41,6 @@ function StandardEmojiCategories({
 
   const parentRef = useRef<HTMLDivElement>(null);
 
-  // Deferred out of module evaluation: canvas-based support detection is
-  // expensive and must only run when the picker actually renders.
   const emojiCategories = useMemo(() => filterSupportedEmojis(emojiData as EmojiGroup[]), []);
 
   const rows = useMemo<Row[]>(() => {

--- a/packages/emoji-picker/src/EmojiPicker/__tests__/EmojiCategories.test.tsx
+++ b/packages/emoji-picker/src/EmojiPicker/__tests__/EmojiCategories.test.tsx
@@ -64,6 +64,12 @@ const mockFilteredEmojis = [
   },
 ];
 
+// Mock emoji support filtering so the rendered categories are deterministic
+// regardless of which other test files have run (bun's mock.module is global)
+mock.module('../../utils/supportedEmojis', () => ({
+  filterSupportedEmojis: () => mockFilteredEmojis,
+}));
+
 const testFilteredEmojisAtom = atom(mockFilteredEmojis);
 const testSkinToneAtom = atom('medium-dark');
 
@@ -102,7 +108,7 @@ describe('EmojiCategories', () => {
 
     // Should find category headers (we have 2 categories in mockFilteredEmojis)
     const headers = container.querySelectorAll('[data-testid="emoji-picker-list-header"]');
-    expect(headers.length).toBe(1);
+    expect(headers.length).toBe(2);
 
     // Should find emoji buttons
     const emojiButtons = container.querySelectorAll('button');

--- a/packages/emoji-picker/src/EmojiPicker/__tests__/importSideEffects.fixture.ts
+++ b/packages/emoji-picker/src/EmojiPicker/__tests__/importSideEffects.fixture.ts
@@ -1,0 +1,34 @@
+// Runs in a standalone `bun run` subprocess (see importSideEffects.test.tsx) so
+// that module evaluation happens with a pristine module cache, unaffected by
+// other test files' imports or `mock.module` calls.
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+
+GlobalRegistrator.register();
+
+// `isEmojiFullySupported` skips canvas detection when NODE_ENV === 'test',
+// which would make this check pass vacuously.
+process.env.NODE_ENV = 'production';
+
+// happy-dom returns null from getContext('2d'), which also short-circuits
+// detection. Stub it with a fake context that counts getImageData calls.
+let getImageDataCalls = 0;
+
+const fakeContext = {
+  canvas: { width: 0, height: 0 },
+  font: '',
+  fillStyle: '',
+  textBaseline: '',
+  measureText: () => ({ width: 0 }),
+  fillText: () => {},
+  clearRect: () => {},
+  getImageData: () => {
+    getImageDataCalls++;
+    return { data: new Uint8ClampedArray(16) };
+  },
+};
+
+(HTMLCanvasElement.prototype as { getContext: unknown }).getContext = () => fakeContext;
+
+await import('../../index');
+
+console.log(JSON.stringify({ getImageDataCalls }));

--- a/packages/emoji-picker/src/EmojiPicker/__tests__/importSideEffects.test.tsx
+++ b/packages/emoji-picker/src/EmojiPicker/__tests__/importSideEffects.test.tsx
@@ -1,0 +1,26 @@
+import { expect, test } from 'bun:test';
+
+// Canvas-based emoji support detection is expensive (thousands of getImageData
+// calls, multi-second main-thread block on some machines), so it must not run
+// as a side effect of merely importing the package. The fixture evaluates the
+// package entry point in a fresh subprocess with a canvas stub that counts
+// getImageData calls; importing alone must trigger zero of them.
+test('importing the package does not trigger canvas emoji support detection', async () => {
+  const fixturePath = new URL('./importSideEffects.fixture.ts', import.meta.url).pathname;
+
+  const proc = Bun.spawn(['bun', 'run', fixturePath], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  expect(exitCode, stderr).toBe(0);
+
+  const { getImageDataCalls } = JSON.parse(stdout.trim());
+  expect(getImageDataCalls).toBe(0);
+});

--- a/packages/emoji-picker/src/atoms/emoji.ts
+++ b/packages/emoji-picker/src/atoms/emoji.ts
@@ -31,25 +31,30 @@ const emojiData = loadJsonData(
 );
 
 const processedEmojiData = processEmojiData(emojiData);
-const defaultEmojis = Object.entries(emojiData).map(([category, group]) => ({
-  category,
-  emojis: (group as any).emojis
-    .filter((emoji: any) => isEmojiFullySupported(emoji))
-    .map((emoji: any) => ({
-      emoji: emoji.emoji,
-      name: emoji.name,
-      slug: emoji.slug,
-      skin_tone_support: emoji.skin_tone_support,
-      skin_tone_support_unicode_version: emoji.skin_tone_support_unicode_version,
-    })),
-}));
+
+// Deferred out of module evaluation: canvas-based support detection is
+// expensive and must only run when the picker actually renders.
+let defaultEmojis: { category: string; emojis: EmojiMetadata[] }[] | undefined;
+const getDefaultEmojis = () =>
+  (defaultEmojis ??= Object.entries(emojiData).map(([category, group]) => ({
+    category,
+    emojis: (group as any).emojis
+      .filter((emoji: any) => isEmojiFullySupported(emoji))
+      .map((emoji: any) => ({
+        emoji: emoji.emoji,
+        name: emoji.name,
+        slug: emoji.slug,
+        skin_tone_support: emoji.skin_tone_support,
+        skin_tone_support_unicode_version: emoji.skin_tone_support_unicode_version,
+      })),
+  })));
 
 // Derived atom for filtered emojis with memoization
 export const filteredEmojisAtom = atom((get) => {
   const search = get(searchAtom);
 
   if (!search.trim()) {
-    return defaultEmojis;
+    return getDefaultEmojis();
   }
 
   return searchEmojis(search, processedEmojiData).map((group) => ({

--- a/packages/emoji-picker/src/atoms/emoji.ts
+++ b/packages/emoji-picker/src/atoms/emoji.ts
@@ -32,8 +32,6 @@ const emojiData = loadJsonData(
 
 const processedEmojiData = processEmojiData(emojiData);
 
-// Deferred out of module evaluation: canvas-based support detection is
-// expensive and must only run when the picker actually renders.
 let defaultEmojis: { category: string; emojis: EmojiMetadata[] }[] | undefined;
 const getDefaultEmojis = () =>
   (defaultEmojis ??= Object.entries(emojiData).map(([category, group]) => ({


### PR DESCRIPTION
## Problem

Merely importing `@ferrucc-io/emoji-picker` runs canvas-based emoji support detection for all 1,906 emojis, synchronously, at module evaluation time. Detection renders each emoji twice (`fillText` × 2 + `getImageData` × 2), producing **3,740 `getImageData` calls** on import (1,870 emojis pass the width pre-check, 2 calls each).

There were three top-level call sites that triggered this during module evaluation:

- `src/EmojiPicker/EmojiCategories.tsx` — `filterSupportedEmojis(...)` at module scope
- `src/EmojiPicker/CustomEmojiCategories.tsx` — same
- `src/atoms/emoji.ts` — `defaultEmojis` computed at module scope via `isEmojiFullySupported(...)`

## Impact

On a real-world Windows/Chrome machine this blocks the main thread for **~5.2 s** at import time. In the most favorable environment measured (Linux software rendering, headless, COLRv1 emoji font) it is still **~0.4 s**. The spread across environments is roughly 100×, but even the lower bound is not acceptable as a synchronous side effect of `import`.

Note to avoid a misdiagnosis: **this is not a GPU issue.** The detection canvas is created with `willReadFrequently: true`, so it is CPU-backed from the start; measuring with `--disable-accelerated-2d-canvas` shows no difference. The cost is the rasterization of color emoji glyphs, not the pixel readback (`getImageData` itself is ~0.004 ms per call). That is why deferring the detection cycle out of the import path is the fix, rather than micro-optimizing the readback.

## Fix

Defer detection until the picker actually renders, without changing the detection logic itself:

- In `EmojiCategories.tsx` / `CustomEmojiCategories.tsx`, the module-scope `const emojiCategories = filterSupportedEmojis(...)` moves into the component as `useMemo(..., [])`.
- In `atoms/emoji.ts`, `defaultEmojis` becomes a lazily-initialized module-level cache, first computed when `filteredEmojisAtom` is read (i.e. when the list renders).

Rendering output is unchanged: the same data is computed by the same code, just at first render instead of at import. The existing `supportCache` continues to deduplicate detection, so each emoji is still probed at most once per session even though there are multiple call sites. Public API (`src/index.ts` exports) is untouched.

### Measurements

Measured with an instrumented page that wraps `getImageData` before dynamically importing the library (Vite dev server, warm module cache).

| | import-time detection work (Windows/Chrome) | import-time detection work (Linux software rendering) |
|---|---|---|
| Before | ~5.2 s main-thread block (3,740 `getImageData` calls) | ~0.4 s (3,740 calls) |
| After | 0 calls — detection no longer runs on import | 0 calls, 0.0 ms (3/3 runs) |

After the fix, importing the library triggers zero canvas work by construction, independent of environment — the regression test asserts this, and the instrumented page confirms it (remaining "import elapsed" of ~60–100 ms on the Linux machine is Vite dev-server module serving, not detection). The detection cost itself is unchanged: it now runs once at the picker's first render instead of at import, deduplicated by `supportCache`.

## Regression test

`importSideEffects.test.tsx` spawns a fresh `bun` subprocess (pristine module cache, unaffected by other test files' `mock.module` calls) that registers happy-dom, stubs `getContext('2d')` with a counting fake (happy-dom returns `null`, which would short-circuit detection), sets `NODE_ENV` to non-test (detection is skipped under `NODE_ENV=test`), imports the package entry point, and asserts **zero** `getImageData` calls. Before this fix the test fails with 3,740 calls; it is what caught the third call site in `atoms/emoji.ts`.

One existing assertion in `EmojiCategories.test.tsx` was updated: the file mocks the emoji data and expects 2 categories (per its own comment), but with eager evaluation the mock never took effect and the assertion was written against real data leaking through. The test now explicitly mocks `filterSupportedEmojis` so it is deterministic regardless of test-file execution order, and asserts the 2 headers it always intended to.

## Verification

- `bun test`: 129 pass, 0 fail (also verified each test file passes when run individually)
- `bun run lint`, `bun run format:check`: clean
- `bun run build` (`build:types` / `build:esm` / `build:cjs`): pass
- `bun run test:e2e`: 10 passed / 9 failed — the 9 failures are identical (same test list) on `master` in the same environment, i.e. pre-existing environment issues, not caused by this change
